### PR TITLE
Improve exception traceback when dealing with NULL pointers in Python

### DIFF
--- a/python/rascaline/status.py
+++ b/python/rascaline/status.py
@@ -26,9 +26,7 @@ def _check_rascal_status_t(status):
 
 
 def _check_rascal_pointer(pointer):
-    try:
-        pointer.contents
-    except ValueError:
+    if not pointer:
         raise RascalError(last_error())
 
 


### PR DESCRIPTION
Previously

```
Traceback (most recent call last):
  File "rascaline/status.py", line 33, in _check_rascal_pointer
    pointer.contents
ValueError: NULL pointer access

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tmp.py", line 10, in <module>
    cutoff_function={"ShiftedCosine": {"width": 0.5}},
  File "rascaline/calculator.py", line 280, in __init__
    super().__init__("spherical_expansion", parameters)
  File "rascaline/calculator.py", line 111, in __init__
    _check_rascal_pointer(self._as_parameter_)
  File "rascaline/status.py", line 35, in _check_rascal_pointer
    raise RascalError(last_error())
rascaline.status.RascalError: json error: unknown variant `GTO`, expected `Gto` at line 1 column 102
```

Now:

```
Traceback (most recent call last):
  File "tmp.py", line 11, in <module>
    cutoff_function={"ShiftedCosine": {"width": 0.5}},
  File "rascaline/calculator.py", line 280, in __init__
    super().__init__("spherical_expansion", parameters)
  File "rascaline/calculator.py", line 111, in __init__
    _check_rascal_pointer(self._as_parameter_)
  File "rascaline/status.py", line 33, in _check_rascal_pointer
    raise RascalError(last_error())
rascaline.status.RascalError: json error: unknown variant `GTO`, expected `Gto` at line 1 column 102
```