### PR TITLE
Finish renaming environments to samples everywhere

### DIFF
--- a/python/rascaline/_rascaline.py
+++ b/python/rascaline/_rascaline.py
@@ -20,8 +20,8 @@ elif arch == "64bit":
 
 class rascal_indexes(enum.Enum):
     RASCAL_INDEXES_FEATURES = 0
-    RASCAL_INDEXES_ENVIRONMENTS = 1
-    RASCAL_INDEXES_GRADIENTS = 2
+    RASCAL_INDEXES_SAMPLES = 1
+    RASCAL_INDEXES_GRADIENT_SAMPLES = 2
 
 
 class rascal_status_t(enum.Enum):

--- a/python/rascaline/descriptor.py
+++ b/python/rascaline/descriptor.py
@@ -48,13 +48,13 @@ class Descriptor:
 
     They contains the values produced by the calculation; as well as metdata to
     interpret these values. In particular, it contains two additional named
-    arrays describing the ``environments`` (associated with rows in the values)
-    and ``features`` (associated with columns in the values).
+    arrays describing the ``samples`` (associated with rows in the values) and
+    ``features`` (associated with columns in the values).
 
     Optionally, a descriptor can also contain gradients of the samples. In this
     case, some additional metadata is available to describe the rows of the
-    gradients array in ``gradients_environments``. The columns of the gradients
-    array are still described by the same ``features``.
+    gradients array in ``gradients_samples``. The columns of the gradients array
+    are still described by the same ``features``.
     """
 
     def __init__(self):
@@ -72,13 +72,11 @@ class Descriptor:
         The values stored in this descriptor by a calculator, as a **read only**
         2D numpy ndarray with ``dtype=np.float64``.
         """
-        environments = c_uintptr_t()
+        samples = c_uintptr_t()
         features = c_uintptr_t()
         data = POINTER(c_double)()
-        self._lib.rascal_descriptor_values(self, data, environments, features)
-        return np_array_view(
-            data, (environments.value, features.value), dtype=np.float64
-        )
+        self._lib.rascal_descriptor_values(self, data, samples, features)
+        return np_array_view(data, (samples.value, features.value), dtype=np.float64)
 
     @property
     def gradients(self):
@@ -87,17 +85,15 @@ class Descriptor:
         only** 2D numpy ndarray with ``dtype=np.float64``, or ``None`` if no
         value was stored.
         """
-        environments = c_uintptr_t()
+        samples = c_uintptr_t()
         features = c_uintptr_t()
         data = POINTER(c_double)()
-        self._lib.rascal_descriptor_gradients(self, data, environments, features)
+        self._lib.rascal_descriptor_gradients(self, data, samples, features)
 
         if not data:
             return None
 
-        return np_array_view(
-            data, (environments.value, features.value), dtype=np.float64
-        )
+        return np_array_view(data, (samples.value, features.value), dtype=np.float64)
 
     def _indexes(self, kind):
         count = c_uintptr_t()
@@ -115,7 +111,7 @@ class Descriptor:
         return Indexes(ptr=ptr, shape=shape, names=names)
 
     @property
-    def environments(self):
+    def samples(self):
         """
         Metdata describing the samples/rows in :py:attr:`Descriptor.values`.
 
@@ -123,7 +119,7 @@ class Descriptor:
         **read only** 2D numpy ndarray with ``dtype=np.float64``. Each column of
         the array is named, and the names are available in ``Indexes.names``.
         """
-        return self._indexes(rascal_indexes.RASCAL_INDEXES_ENVIRONMENTS)
+        return self._indexes(rascal_indexes.RASCAL_INDEXES_SAMPLES)
 
     @property
     def features(self):
@@ -138,18 +134,18 @@ class Descriptor:
         return self._indexes(rascal_indexes.RASCAL_INDEXES_FEATURES)
 
     @property
-    def gradients_environments(self):
+    def gradients_samples(self):
         """
         Metdata describing the rows in :py:attr:`Descriptor.gradients`.
 
         If there are no gradients stored in this descriptor,
-        ``gradients_environments`` is ``None``.
+        ``gradients_samples`` is ``None``.
 
         This is stored as a :py:class:`rascaline.descriptor.Indexes` wrapping a
         **read only** 2D numpy ndarray with ``dtype=np.float64``. Each column of
         the array is named, and the names are available in ``Indexes.names``.
         """
-        return self._indexes(rascal_indexes.RASCAL_INDEXES_GRADIENTS)
+        return self._indexes(rascal_indexes.RASCAL_INDEXES_GRADIENT_SAMPLES)
 
     def densify(self, variables):
         """

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -71,7 +71,7 @@ class TestDummyCalculator(unittest.TestCase):
         descriptor = calculator.compute(system)
 
         # From a selection scheme, using numpy array indexing
-        samples = descriptor.environments[[0, 2]]
+        samples = descriptor.samples[[0, 2]]
         descriptor = calculator.compute(system, selected_samples=samples)
 
         values = descriptor.values

--- a/python/tests/descriptor.py
+++ b/python/tests/descriptor.py
@@ -17,17 +17,17 @@ class TestEmptyDescriptor(unittest.TestCase):
         descriptor = Descriptor()
         self.assertEqual(descriptor.gradients, None)
 
-    def test_environments(self):
+    def test_samples(self):
         descriptor = Descriptor()
-        self.assertEqual(len(descriptor.environments), 0)
+        self.assertEqual(len(descriptor.samples), 0)
 
     def test_features(self):
         descriptor = Descriptor()
         self.assertEqual(len(descriptor.features), 0)
 
-    def test_gradients_environments(self):
+    def test_gradients_samples(self):
         descriptor = Descriptor()
-        self.assertEqual(len(descriptor.gradients_environments), 0)
+        self.assertEqual(len(descriptor.gradients_samples), 0)
 
 
 class TestDummyDescriptor(unittest.TestCase):
@@ -69,82 +69,80 @@ class TestDummyDescriptor(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
             gradients[0] = (3, 4)
 
-    def test_environments(self):
+    def test_samples(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
         descriptor = calculator.compute(system)
 
-        environments = descriptor.environments
-        self.assertEqual(len(environments), 4)
+        samples = descriptor.samples
+        self.assertEqual(len(samples), 4)
 
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
-            environments[0] = (3, 4)
+            samples[0] = (3, 4)
 
-        self.assertTrue(np.all(environments["structure"] == [0, 0, 0, 0]))
-        self.assertTrue(np.all(environments["center"] == [0, 1, 2, 3]))
+        self.assertTrue(np.all(samples["structure"] == [0, 0, 0, 0]))
+        self.assertTrue(np.all(samples["center"] == [0, 1, 2, 3]))
 
         # view & reshape for easier direct comparison of values
         # numpy only consider structured arrays to be equal if they have
         # the same dtype
-        environments = environments.view(dtype=np.int32).reshape(
-            (environments.shape[0], -1)
-        )
-        self.assertTrue(np.all(environments[0] == [0, 0]))
-        self.assertTrue(np.all(environments[1] == [0, 1]))
-        self.assertTrue(np.all(environments[2] == [0, 2]))
-        self.assertTrue(np.all(environments[3] == [0, 3]))
+        samples = samples.view(dtype=np.int32).reshape((samples.shape[0], -1))
+        self.assertTrue(np.all(samples[0] == [0, 0]))
+        self.assertTrue(np.all(samples[1] == [0, 1]))
+        self.assertTrue(np.all(samples[2] == [0, 2]))
+        self.assertTrue(np.all(samples[3] == [0, 3]))
 
     def test_gradient_indexes(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
         descriptor = calculator.compute(system)
-        self.assertEqual(len(descriptor.gradients_environments), 0)
+        self.assertEqual(len(descriptor.gradients_samples), 0)
 
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=True)
         descriptor = calculator.compute(system)
-        gradients_environments = descriptor.gradients_environments
-        self.assertEqual(len(gradients_environments), 18)
+        gradients_samples = descriptor.gradients_samples
+        self.assertEqual(len(gradients_samples), 18)
 
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
-            gradients_environments[0] = (3, 4)
+            gradients_samples[0] = (3, 4)
 
         expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        self.assertTrue(np.all(gradients_environments["structure"] == expected))
+        self.assertTrue(np.all(gradients_samples["structure"] == expected))
 
         expected = [0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3]
-        self.assertTrue(np.all(gradients_environments["center"] == expected))
+        self.assertTrue(np.all(gradients_samples["center"] == expected))
 
         expected = [1, 1, 1, 0, 0, 0, 2, 2, 2, 1, 1, 1, 3, 3, 3, 2, 2, 2]
-        self.assertTrue(np.all(gradients_environments["neighbor"] == expected))
+        self.assertTrue(np.all(gradients_samples["neighbor"] == expected))
 
         expected = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
-        self.assertTrue(np.all(gradients_environments["spatial"] == expected))
+        self.assertTrue(np.all(gradients_samples["spatial"] == expected))
 
         # view & reshape for easier direct comparison of values
         # numpy only consider structured arrays to be equal if they have
         # the same dtype
-        gradients_environments = gradients_environments.view(dtype=np.int32).reshape(
-            (gradients_environments.shape[0], -1)
+        gradients_samples = gradients_samples.view(dtype=np.int32).reshape(
+            (gradients_samples.shape[0], -1)
         )
 
-        self.assertTrue(np.all(gradients_environments[0] == [0, 0, 1, 0]))
-        self.assertTrue(np.all(gradients_environments[1] == [0, 0, 1, 1]))
-        self.assertTrue(np.all(gradients_environments[2] == [0, 0, 1, 2]))
-        self.assertTrue(np.all(gradients_environments[3] == [0, 1, 0, 0]))
-        self.assertTrue(np.all(gradients_environments[4] == [0, 1, 0, 1]))
-        self.assertTrue(np.all(gradients_environments[5] == [0, 1, 0, 2]))
-        self.assertTrue(np.all(gradients_environments[6] == [0, 1, 2, 0]))
-        self.assertTrue(np.all(gradients_environments[7] == [0, 1, 2, 1]))
-        self.assertTrue(np.all(gradients_environments[8] == [0, 1, 2, 2]))
-        self.assertTrue(np.all(gradients_environments[9] == [0, 2, 1, 0]))
-        self.assertTrue(np.all(gradients_environments[10] == [0, 2, 1, 1]))
-        self.assertTrue(np.all(gradients_environments[11] == [0, 2, 1, 2]))
-        self.assertTrue(np.all(gradients_environments[12] == [0, 2, 3, 0]))
-        self.assertTrue(np.all(gradients_environments[13] == [0, 2, 3, 1]))
-        self.assertTrue(np.all(gradients_environments[14] == [0, 2, 3, 2]))
-        self.assertTrue(np.all(gradients_environments[15] == [0, 3, 2, 0]))
-        self.assertTrue(np.all(gradients_environments[16] == [0, 3, 2, 1]))
-        self.assertTrue(np.all(gradients_environments[17] == [0, 3, 2, 2]))
+        self.assertTrue(np.all(gradients_samples[0] == [0, 0, 1, 0]))
+        self.assertTrue(np.all(gradients_samples[1] == [0, 0, 1, 1]))
+        self.assertTrue(np.all(gradients_samples[2] == [0, 0, 1, 2]))
+        self.assertTrue(np.all(gradients_samples[3] == [0, 1, 0, 0]))
+        self.assertTrue(np.all(gradients_samples[4] == [0, 1, 0, 1]))
+        self.assertTrue(np.all(gradients_samples[5] == [0, 1, 0, 2]))
+        self.assertTrue(np.all(gradients_samples[6] == [0, 1, 2, 0]))
+        self.assertTrue(np.all(gradients_samples[7] == [0, 1, 2, 1]))
+        self.assertTrue(np.all(gradients_samples[8] == [0, 1, 2, 2]))
+        self.assertTrue(np.all(gradients_samples[9] == [0, 2, 1, 0]))
+        self.assertTrue(np.all(gradients_samples[10] == [0, 2, 1, 1]))
+        self.assertTrue(np.all(gradients_samples[11] == [0, 2, 1, 2]))
+        self.assertTrue(np.all(gradients_samples[12] == [0, 2, 3, 0]))
+        self.assertTrue(np.all(gradients_samples[13] == [0, 2, 3, 1]))
+        self.assertTrue(np.all(gradients_samples[14] == [0, 2, 3, 2]))
+        self.assertTrue(np.all(gradients_samples[15] == [0, 3, 2, 0]))
+        self.assertTrue(np.all(gradients_samples[16] == [0, 3, 2, 1]))
+        self.assertTrue(np.all(gradients_samples[17] == [0, 3, 2, 2]))
 
     def test_features(self):
         system = TestSystem()

--- a/rascaline-c-api/rascaline.h
+++ b/rascaline-c-api/rascaline.h
@@ -17,12 +17,12 @@ typedef enum rascal_indexes {
   /**
    * The samples index, describing different samples in the representation
    */
-  RASCAL_INDEXES_ENVIRONMENTS = 1,
+  RASCAL_INDEXES_SAMPLES = 1,
   /**
-   * The gradient index, describing the gradients of samples in the
+   * The gradient samples index, describing the gradients of samples in the
    * representation with respect to other atoms
    */
-  RASCAL_INDEXES_GRADIENTS = 2,
+  RASCAL_INDEXES_GRADIENT_SAMPLES = 2,
 } rascal_indexes;
 
 /**

--- a/rascaline-c-api/src/descriptor.rs
+++ b/rascaline-c-api/src/descriptor.rs
@@ -161,10 +161,10 @@ pub enum rascal_indexes {
     /// The feature index, describing the features of the representation
     RASCAL_INDEXES_FEATURES = 0,
     /// The samples index, describing different samples in the representation
-    RASCAL_INDEXES_ENVIRONMENTS = 1,
-    /// The gradient index, describing the gradients of samples in the
+    RASCAL_INDEXES_SAMPLES = 1,
+    /// The gradient samples index, describing the gradients of samples in the
     /// representation with respect to other atoms
-    RASCAL_INDEXES_GRADIENTS = 2,
+    RASCAL_INDEXES_GRADIENT_SAMPLES = 2,
 }
 
 /// Get the values associated with one of the `indexes` in the given
@@ -205,9 +205,9 @@ pub unsafe extern fn rascal_descriptor_indexes(
 
         let indexes = match indexes {
             rascal_indexes::RASCAL_INDEXES_FEATURES => &(*descriptor).features,
-            rascal_indexes::RASCAL_INDEXES_ENVIRONMENTS => &(*descriptor).environments,
-            rascal_indexes::RASCAL_INDEXES_GRADIENTS => {
-                if let Some(indexes) = &(*descriptor).gradients_indexes {
+            rascal_indexes::RASCAL_INDEXES_SAMPLES => &(*descriptor).samples,
+            rascal_indexes::RASCAL_INDEXES_GRADIENT_SAMPLES => {
+                if let Some(indexes) = &(*descriptor).gradients_samples {
                     indexes
                 } else {
                     *data = std::ptr::null();
@@ -262,9 +262,9 @@ pub unsafe extern fn rascal_descriptor_indexes_names(
 
         let indexes = match indexes {
             rascal_indexes::RASCAL_INDEXES_FEATURES => &(*descriptor).features,
-            rascal_indexes::RASCAL_INDEXES_ENVIRONMENTS => &(*descriptor).environments,
-            rascal_indexes::RASCAL_INDEXES_GRADIENTS => {
-                if let Some(indexes) = &(*descriptor).gradients_indexes {
+            rascal_indexes::RASCAL_INDEXES_SAMPLES => &(*descriptor).samples,
+            rascal_indexes::RASCAL_INDEXES_GRADIENT_SAMPLES => {
+                if let Some(indexes) = &(*descriptor).gradients_samples {
                     indexes
                 } else {
                     for i in 0..size {

--- a/rascaline-c-api/tests/c-api/calculator.cpp
+++ b/rascaline-c-api/tests/c-api/calculator.cpp
@@ -143,7 +143,7 @@ TEST_CASE("Compute descriptor") {
         auto expected = std::vector<int32_t>{
             0, 0, /**/ 0, 1, /**/ 0, 2, /**/ 0, 3,
         };
-        check_indexes(descriptor, RASCAL_INDEXES_ENVIRONMENTS, {"structure", "center"}, expected, 4, 2);
+        check_indexes(descriptor, RASCAL_INDEXES_SAMPLES, {"structure", "center"}, expected, 4, 2);
 
         expected = std::vector<int32_t>{
             1, 0, /**/ 0, 1,
@@ -198,7 +198,7 @@ TEST_CASE("Compute descriptor") {
             calculator, descriptor, &system, 1, options
         ));
 
-        check_indexes(descriptor, RASCAL_INDEXES_ENVIRONMENTS, {"structure", "center"}, samples, 2, 2);
+        check_indexes(descriptor, RASCAL_INDEXES_SAMPLES, {"structure", "center"}, samples, 2, 2);
 
         auto expected = std::vector<int32_t>{
             1, 0, /**/ 0, 1
@@ -255,7 +255,7 @@ TEST_CASE("Compute descriptor") {
         auto expected = std::vector<int32_t>{
             0, 0, /**/ 0, 1, /**/ 0, 2, /**/ 0, 3,
         };
-        check_indexes(descriptor, RASCAL_INDEXES_ENVIRONMENTS, {"structure", "center"}, expected, 4, 2);
+        check_indexes(descriptor, RASCAL_INDEXES_SAMPLES, {"structure", "center"}, expected, 4, 2);
 
         check_indexes(descriptor, RASCAL_INDEXES_FEATURES, {"index_delta", "x_y_z"}, features, 1, 2);
 

--- a/rascaline-c-api/tests/c-api/descriptor.cpp
+++ b/rascaline-c-api/tests/c-api/descriptor.cpp
@@ -70,7 +70,7 @@ TEST_CASE("rascal_descriptor_t") {
         rascal_descriptor_free(descriptor);
     }
 
-    SECTION("environments") {
+    SECTION("samples") {
         auto* descriptor = rascal_descriptor();
         REQUIRE(descriptor != nullptr);
 
@@ -79,21 +79,21 @@ TEST_CASE("rascal_descriptor_t") {
         uintptr_t size = 0;
 
         CHECK_SUCCESS(rascal_descriptor_indexes(
-            descriptor, RASCAL_INDEXES_ENVIRONMENTS, &data, &count, &size
+            descriptor, RASCAL_INDEXES_SAMPLES, &data, &count, &size
         ));
         CHECK(data == nullptr);
         CHECK(count == 0);
         CHECK(size == 0);
 
         const char* names[2] = {"foo", "bar"};
-        rascal_descriptor_indexes_names(descriptor, RASCAL_INDEXES_ENVIRONMENTS, names, 2);
+        rascal_descriptor_indexes_names(descriptor, RASCAL_INDEXES_SAMPLES, names, 2);
         CHECK(names[0] == nullptr);
         CHECK(names[1] == nullptr);
 
 
         compute_descriptor(descriptor);
         CHECK_SUCCESS(rascal_descriptor_indexes(
-            descriptor, RASCAL_INDEXES_ENVIRONMENTS, &data, &count, &size
+            descriptor, RASCAL_INDEXES_SAMPLES, &data, &count, &size
         ));
         CHECK(data != nullptr);
         CHECK(count == 4);
@@ -106,7 +106,7 @@ TEST_CASE("rascal_descriptor_t") {
         }
 
         CHECK_SUCCESS(rascal_descriptor_indexes_names(
-            descriptor, RASCAL_INDEXES_ENVIRONMENTS, names, 2
+            descriptor, RASCAL_INDEXES_SAMPLES, names, 2
         ));
         CHECK(names[0] == std::string("structure"));
         CHECK(names[1] == std::string("center"));
@@ -145,7 +145,7 @@ TEST_CASE("rascal_descriptor_t") {
         CHECK_SUCCESS(rascal_descriptor_free(descriptor));
     }
 
-    SECTION("gradient indexes") {
+    SECTION("gradient samples") {
         auto* descriptor = rascal_descriptor();
         REQUIRE(descriptor != nullptr);
 
@@ -154,14 +154,14 @@ TEST_CASE("rascal_descriptor_t") {
         uintptr_t size = 0;
 
         CHECK_SUCCESS(rascal_descriptor_indexes(
-            descriptor, RASCAL_INDEXES_GRADIENTS, &data, &count, &size
+            descriptor, RASCAL_INDEXES_GRADIENT_SAMPLES, &data, &count, &size
         ));
         CHECK(data == nullptr);
         CHECK(count == 0);
         CHECK(size == 0);
 
         const char* names[4] = {"foo", "bar", "fizz", "buzz"};
-        rascal_descriptor_indexes_names(descriptor, RASCAL_INDEXES_GRADIENTS, names, 4);
+        rascal_descriptor_indexes_names(descriptor, RASCAL_INDEXES_GRADIENT_SAMPLES, names, 4);
         CHECK(names[0] == nullptr);
         CHECK(names[1] == nullptr);
         CHECK(names[2] == nullptr);
@@ -170,7 +170,7 @@ TEST_CASE("rascal_descriptor_t") {
 
         compute_descriptor(descriptor);
         CHECK_SUCCESS(rascal_descriptor_indexes(
-            descriptor, RASCAL_INDEXES_GRADIENTS, &data, &count, &size
+            descriptor, RASCAL_INDEXES_GRADIENT_SAMPLES, &data, &count, &size
         ));
         CHECK(data != nullptr);
         CHECK(count == 18);
@@ -189,7 +189,7 @@ TEST_CASE("rascal_descriptor_t") {
         CHECK(std::vector<int32_t>(data, data + (count * size)) == expected);
 
         CHECK_SUCCESS(rascal_descriptor_indexes_names(
-            descriptor, RASCAL_INDEXES_GRADIENTS, names, 4
+            descriptor, RASCAL_INDEXES_GRADIENT_SAMPLES, names, 4
         ));
         CHECK(names[0] == std::string("structure"));
         CHECK(names[1] == std::string("center"));

--- a/rascaline/benches/soap-power-spectrum.rs
+++ b/rascaline/benches/soap-power-spectrum.rs
@@ -66,8 +66,8 @@ fn run_soap_power_spectrum(mut group: BenchmarkGroup<WallTime>, path: &str) {
             let mut calculator = SoapPowerSpectrum::new(parameters);
 
             let mut descriptor = Descriptor::new();
-            let environments = calculator.environments();
-            descriptor.prepare(environments.indexes(&mut systems), calculator.features());
+            let samples = calculator.samples();
+            descriptor.prepare(samples.indexes(&mut systems), calculator.features());
 
             group.bench_function(&format!("n_max = {}, l_max = {}", max_radial, max_angular), |b| b.iter_custom(|repeat| {
                 let start = std::time::Instant::now();

--- a/rascaline/benches/spherical-expansion.rs
+++ b/rascaline/benches/spherical-expansion.rs
@@ -41,8 +41,7 @@ fn spherical_expansion(c: &mut Criterion) {
             let mut calculator = SphericalExpansion::new(parameters);
 
             let mut descriptor = Descriptor::new();
-            let environments = calculator.environments();
-            descriptor.prepare(environments.indexes(systems), calculator.features());
+            descriptor.prepare(calculator.samples().indexes(systems), calculator.features());
 
             group.bench_function(&format!("n_max = {}, l_max = {}", max_radial, max_angular), |b| b.iter_custom(|repeat| {
                 let start = std::time::Instant::now();
@@ -78,8 +77,7 @@ fn spherical_expansion_gradients(c: &mut Criterion) {
             let mut calculator = SphericalExpansion::new(parameters);
 
             let mut descriptor = Descriptor::new();
-            let environments = calculator.environments();
-            let (samples, gradients) = environments.with_gradients(systems);
+            let (samples, gradients) = calculator.samples().with_gradients(systems);
             descriptor.prepare_gradients(samples, gradients.unwrap(), calculator.features());
 
             group.bench_function(&format!("n_max = {}, l_max = {}", max_radial, max_angular), |b| b.iter_custom(|repeat| {

--- a/rascaline/src/calculator.rs
+++ b/rascaline/src/calculator.rs
@@ -56,13 +56,13 @@ impl<'a> SelectedIndexes<'a> {
     ) -> Result<Indexes, Error> {
         let indexes = match self {
             SelectedIndexes::All => {
-                let environments = calculator.environments();
-                environments.indexes(systems)
+                let samples = calculator.samples();
+                samples.indexes(systems)
             },
             SelectedIndexes::Some(indexes) => indexes,
             SelectedIndexes::FromC(list) => {
-                let environments = calculator.environments();
-                let mut builder = IndexesBuilder::new(environments.names());
+                let samples = calculator.samples();
+                let mut builder = IndexesBuilder::new(samples.names());
 
                 if list.len() % builder.size() != 0 {
                     return Err(Error::InvalidParameter(format!(
@@ -78,7 +78,7 @@ impl<'a> SelectedIndexes<'a> {
             }
         };
 
-        calculator.check_environments(&indexes, systems);
+        calculator.check_samples(&indexes, systems);
         return Ok(indexes);
     }
 }
@@ -184,11 +184,11 @@ impl Calculator {
         let features = options.selected_features.into_features(&*self.implementation)?;
         let samples = options.selected_samples.into_samples(&*self.implementation, systems)?;
 
-        let environments_builder = self.implementation.environments();
+        let samples_builder = self.implementation.samples();
         if self.implementation.compute_gradients() {
-            let gradients = environments_builder
+            let gradients = samples_builder
                 .gradients_for(systems, &samples)
-                .expect("this environments definition do not support gradients");
+                .expect("this samples definition do not support gradients");
             descriptor.prepare_gradients(samples, gradients, features);
         } else {
             descriptor.prepare(samples, features);

--- a/rascaline/src/calculators/mod.rs
+++ b/rascaline/src/calculators/mod.rs
@@ -1,4 +1,4 @@
-use crate::descriptor::{Descriptor, Indexes, EnvironmentIndexes};
+use crate::descriptor::{Descriptor, Indexes, SamplesIndexes};
 use crate::system::System;
 
 #[cfg(test)]
@@ -20,28 +20,28 @@ pub trait CalculatorBase: std::panic::RefUnwindSafe {
     /// Get the default set of features for this Calculator
     fn features(&self) -> Indexes;
 
-    /// Get the default set of environments for this Calculator
-    fn environments(&self) -> Box<dyn EnvironmentIndexes>;
-    /// Does this environment compute gradients?
+    /// Get the default set of samples for this Calculator
+    fn samples(&self) -> Box<dyn SamplesIndexes>;
+    /// Does this calculator compute gradients?
     fn compute_gradients(&self) -> bool;
 
     /// Check that the given indexes are valid feature indexes for this
     /// Calculator. This is used by `Calculator::compute_partial` to ensure
     /// only valid features are requested
     fn check_features(&self, indexes: &Indexes);
-    /// Check that the given indexes are valid environment indexes for this
+    /// Check that the given indexes are valid samples indexes for this
     /// Calculator. This is used by `Calculator::compute_partial` to ensure
-    /// only valid environments are requested
-    fn check_environments(&self, indexes: &Indexes, systems: &mut [&mut dyn System]);
+    /// only valid samples are requested
+    fn check_samples(&self, indexes: &Indexes, systems: &mut [&mut dyn System]);
 
     /// Core implementation of the descriptor.
     ///
-    /// This function should compute the descriptor only for environments in
-    /// `descriptor.environments` and computing only features in
-    /// `descriptor.features`. By default, these would correspond to the
-    /// environments and features coming from `Descriptor::environments` and
-    /// `Descriptor::features` respectively; but this can be overrode to only
-    /// compute them on a subset though `Descriptor::compute_partial`.
+    /// This function should compute the descriptor only for samples in
+    /// `descriptor.samples` and computing only features in
+    /// `descriptor.features`. By default, these would correspond to the samples
+    /// and features coming from `Descriptor::samples()` and
+    /// `Descriptor::features()` respectively; but the user can request only a
+    /// subset of them.
     fn compute(&mut self, systems: &mut [&mut dyn System], descriptor: &mut Descriptor);
 }
 

--- a/rascaline/src/calculators/tests_utils.rs
+++ b/rascaline/src/calculators/tests_utils.rs
@@ -24,7 +24,7 @@ pub fn compute_partial(
     let mut full = Descriptor::new();
     calculator.compute(&mut systems.get(), &mut full, Default::default()).unwrap();
 
-    // partial set of features, all environments
+    // partial set of features, all samples
     let mut partial = Descriptor::new();
     let options = CalculationOptions {
         selected_samples: SelectedIndexes::All,
@@ -33,7 +33,7 @@ pub fn compute_partial(
     };
     calculator.compute(&mut systems.get(), &mut partial, options).unwrap();
 
-    assert_eq!(full.environments, partial.environments);
+    assert_eq!(full.samples, partial.samples);
     for (partial_i, feature) in features.iter().enumerate() {
         let index = full.features.position(feature).unwrap();
         assert_eq!(
@@ -58,8 +58,8 @@ pub fn compute_partial(
     calculator.compute(&mut systems.get(), &mut partial, options).unwrap();
 
     assert_eq!(full.features, partial.features);
-    for (partial_i, environment) in samples.iter().enumerate() {
-        let index = full.environments.position(environment).unwrap();
+    for (partial_i, sample) in samples.iter().enumerate() {
+        let index = full.samples.position(sample).unwrap();
         assert_eq!(
             full.values.slice(s![index, ..]),
             partial.values.slice(s![partial_i, ..])
@@ -67,8 +67,8 @@ pub fn compute_partial(
     }
 
     if gradients {
-        for (partial_i, environment) in partial.gradients_indexes.as_ref().unwrap().iter().enumerate() {
-            let index = full.gradients_indexes.as_ref().unwrap().position(environment).unwrap();
+        for (partial_i, sample) in partial.gradients_samples.as_ref().unwrap().iter().enumerate() {
+            let index = full.gradients_samples.as_ref().unwrap().position(sample).unwrap();
             assert_eq!(
                 full.gradients.as_ref().unwrap().slice(s![index, ..]),
                 partial.gradients.as_ref().unwrap().slice(s![partial_i, ..])
@@ -83,25 +83,25 @@ pub fn compute_partial(
         ..Default::default()
     };
     calculator.compute(&mut systems.get(), &mut partial, options).unwrap();
-    for (env_i, environment) in samples.iter().enumerate() {
+    for (sample_i, sample) in samples.iter().enumerate() {
         for (feature_i, feature) in features.iter().enumerate() {
-            let full_env = full.environments.position(environment).unwrap();
-            let full_feature = full.features.position(feature).unwrap();
+            let full_sample_i = full.samples.position(sample).unwrap();
+            let full_feature_i = full.features.position(feature).unwrap();
             assert_eq!(
-                full.values[[full_env, full_feature]],
-                partial.values[[env_i, feature_i]]
+                full.values[[full_sample_i, full_feature_i]],
+                partial.values[[sample_i, feature_i]]
             );
         }
     }
 
     if gradients {
-        for (env_i, environment) in partial.gradients_indexes.as_ref().unwrap().iter().enumerate() {
+        for (sample_i, sample) in partial.gradients_samples.as_ref().unwrap().iter().enumerate() {
             for (feature_i, feature) in features.iter().enumerate() {
-                let full_env = full.gradients_indexes.as_ref().unwrap().position(environment).unwrap();
-                let full_feature = full.features.position(feature).unwrap();
+                let full_sample_i = full.gradients_samples.as_ref().unwrap().position(sample).unwrap();
+                let full_feature_i = full.features.position(feature).unwrap();
                 assert_eq!(
-                    full.gradients.as_ref().unwrap()[[full_env, full_feature]],
-                    partial.gradients.as_ref().unwrap()[[env_i, feature_i]]
+                    full.gradients.as_ref().unwrap()[[full_sample_i, full_feature_i]],
+                    partial.gradients.as_ref().unwrap()[[sample_i, feature_i]]
                 );
             }
         }
@@ -120,9 +120,9 @@ pub struct MovedAtomIndex {
 pub struct ChangedGradientIndex {
     /// Position of the changed sample in the full gradients matrix
     pub(crate) gradient_index: usize,
-    /// Sample (NOT gradient) descriptor corresponding with which this gradient
-    /// sample is associated
-    pub(crate) environment: Vec<IndexValue>,
+    /// Sample (NOT gradient) descriptor to which this gradient sample is
+    /// associated
+    pub(crate) sample: Vec<IndexValue>,
 }
 
 /// Check that analytical gradients agree with a finite difference calculation
@@ -138,7 +138,7 @@ pub fn finite_difference(
     let mut reference = Descriptor::new();
     calculator.compute(&mut [&mut system], &mut reference, Default::default()).unwrap();
 
-    let gradients_indexes = reference.gradients_indexes.as_ref().unwrap();
+    let gradients_samples = reference.gradients_samples.as_ref().unwrap();
 
     let delta = 1e-9;
     let gradients = reference.gradients.as_ref().unwrap();
@@ -154,14 +154,17 @@ pub fn finite_difference(
                 spatial: spatial,
             };
 
-            for changed in compute_modified_indexes(&gradients_indexes, moved) {
-                let env_i = reference.environments.position(&changed.environment).expect(
-                    "missing environment in reference values"
+            for changed in compute_modified_indexes(&gradients_samples, moved) {
+                let sample_i = reference.samples.position(&changed.sample).expect(
+                    "missing sample in reference values"
                 );
-                assert_eq!(updated.environments.position(&changed.environment).unwrap(), env_i);
+                assert_eq!(
+                    updated.samples.position(&changed.sample).unwrap(),
+                    sample_i
+                );
 
-                let value = reference.values.slice(s![env_i, ..]);
-                let value_delta = updated.values.slice(s![env_i, ..]);
+                let value = reference.values.slice(s![sample_i, ..]);
+                let value_delta = updated.values.slice(s![sample_i, ..]);
                 let gradient = gradients.slice(s![changed.gradient_index, ..]);
 
                 assert_eq!(value.shape(), value_delta.shape());

--- a/rascaline/src/descriptor/indexes/index.rs
+++ b/rascaline/src/descriptor/indexes/index.rs
@@ -278,8 +278,7 @@ impl std::ops::Index<usize> for Indexes {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
-pub trait EnvironmentIndexes {
+pub trait SamplesIndexes {
     fn names(&self) -> Vec<&str>;
 
     fn indexes(&self, systems: &mut [&mut dyn System]) -> Indexes;

--- a/rascaline/src/descriptor/indexes/mod.rs
+++ b/rascaline/src/descriptor/indexes/mod.rs
@@ -1,9 +1,11 @@
-mod index;
-pub use self::index::{IndexValue, Indexes, IndexesBuilder, EnvironmentIndexes};
+#![allow(clippy::module_name_repetitions)]
 
-mod environments;
-pub use self::environments::{StructureEnvironment, AtomEnvironment};
+mod index;
+pub use self::index::{IndexValue, Indexes, IndexesBuilder, SamplesIndexes};
+
+mod samples;
+pub use self::samples::{StructureSamples, AtomSamples};
 
 mod species;
-pub use self::species::{StructureSpeciesEnvironment, AtomSpeciesEnvironment};
-pub use self::species::{ThreeBodiesSpeciesEnvironment};
+pub use self::species::{StructureSpeciesSamples, AtomSpeciesSamples};
+pub use self::species::{ThreeBodiesSpeciesSamples};

--- a/rascaline/src/descriptor/mod.rs
+++ b/rascaline/src/descriptor/mod.rs
@@ -1,9 +1,9 @@
 mod indexes;
 pub use self::indexes::{Indexes, IndexesBuilder, IndexValue};
-pub use self::indexes::EnvironmentIndexes;
-pub use self::indexes::{StructureEnvironment, AtomEnvironment};
-pub use self::indexes::{StructureSpeciesEnvironment, AtomSpeciesEnvironment};
-pub use self::indexes::{ThreeBodiesSpeciesEnvironment};
+pub use self::indexes::SamplesIndexes;
+pub use self::indexes::{StructureSamples, AtomSamples};
+pub use self::indexes::{StructureSpeciesSamples, AtomSpeciesSamples};
+pub use self::indexes::{ThreeBodiesSpeciesSamples};
 
 #[allow(clippy::module_inception)]
 mod descriptor;


### PR DESCRIPTION
`Environment` only directly apply to "atom-centered" environments, and leave on the side descriptors with one sample per structure.