### PR TITLE
Use &mut [Box<dyn System>] instead of &mut [&mut dyn System]

### DIFF
--- a/rascaline-c-api/src/calculator.rs
+++ b/rascaline-c-api/src/calculator.rs
@@ -234,14 +234,14 @@ pub unsafe extern fn rascal_calculator_compute(
         }
         check_pointers!(calculator, descriptor, systems);
 
-        // Create a Vec<&mut dyn System> from the passed systems
-        let systems = std::slice::from_raw_parts_mut(systems, systems_count);
-        let mut references = Vec::new();
-        for system in systems {
-            references.push(system as &mut dyn System);
+        // Create a Vec<Box<dyn System>> from the passed systems
+        let c_systems = std::slice::from_raw_parts_mut(systems, systems_count);
+        let mut systems = Vec::with_capacity(c_systems.len());
+        for system in c_systems {
+            systems.push(Box::new(system) as Box<dyn System>);
         }
 
         let options = (&options).into();
-        (*calculator).compute(&mut references, &mut *descriptor, options)
+        (*calculator).compute(&mut systems, &mut *descriptor, options)
     })
 }

--- a/rascaline-c-api/src/system.rs
+++ b/rascaline-c-api/src/system.rs
@@ -81,7 +81,7 @@ pub struct rascal_system_t {
     pairs_containing: Option<unsafe extern fn(user_data: *const c_void, center: usize, pairs: *mut *const rascal_pair_t, count: *mut usize)>,
 }
 
-impl System for rascal_system_t {
+impl<'a> System for &'a mut rascal_system_t {
     fn size(&self) -> usize {
         let mut value = 0;
         let function = self.size.expect("rascal_system_t.size is NULL");

--- a/rascaline/benches/spherical-expansion.rs
+++ b/rascaline/benches/spherical-expansion.rs
@@ -23,9 +23,9 @@ fn spherical_expansion(c: &mut Criterion) {
     group.noise_threshold(0.05);
     group.measurement_time(std::time::Duration::from_secs(10));
 
-    let mut system = SimpleSystem::from_xyz(UnitCell::infinite(), TESTING_FRAME);
+    let system = SimpleSystem::from_xyz(UnitCell::infinite(), TESTING_FRAME);
     let n_centers = system.size();
-    let systems = &mut [&mut system as &mut dyn System];
+    let systems = &mut [Box::new(system) as Box<dyn System>];
 
     for &max_radial in black_box(&[2, 8, 14]) {
         for &max_angular in black_box(&[1, 7, 15]) {
@@ -59,9 +59,9 @@ fn spherical_expansion_gradients(c: &mut Criterion) {
     group.noise_threshold(0.05);
     group.measurement_time(std::time::Duration::from_secs(10));
 
-    let mut system = SimpleSystem::from_xyz(UnitCell::infinite(), TESTING_FRAME);
+    let system = SimpleSystem::from_xyz(UnitCell::infinite(), TESTING_FRAME);
     let n_centers = system.size();
-    let systems = &mut [&mut system as &mut dyn System];
+    let systems = &mut [Box::new(system) as Box<dyn System>];
 
     for &max_radial in black_box(&[2, 8, 14]) {
         for &max_angular in black_box(&[1, 7, 15]) {

--- a/rascaline/examples/compute-soap.rs
+++ b/rascaline/examples/compute-soap.rs
@@ -8,14 +8,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file_content = std::fs::read_to_string(&path)?;
         // WARNING: this function only read the first step of the file
         let system = SimpleSystem::from_xyz(UnitCell::infinite(), &file_content);
-        systems.push(system);
+        systems.push(Box::new(system) as Box<dyn System>);
     }
-
-    // transform the vector of SimpleSystems to a vector of trait objects
-    let mut references = systems.iter_mut()
-        .map(|s| s as &mut dyn System)
-        .collect::<Vec<_>>();
-
 
     // pass hyper-parameters as JSON
     let parameters = "{
@@ -38,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut descriptor = Descriptor::new();
 
     // run the calculation using default options
-    calculator.compute(&mut references, &mut descriptor, Default::default())?;
+    calculator.compute(&mut systems, &mut descriptor, Default::default())?;
 
     // Transform the descriptor to dense representation,
     // with one sample for each atom-centered environment

--- a/rascaline/src/calculators/mod.rs
+++ b/rascaline/src/calculators/mod.rs
@@ -32,7 +32,7 @@ pub trait CalculatorBase: std::panic::RefUnwindSafe {
     /// Check that the given indexes are valid samples indexes for this
     /// Calculator. This is used by `Calculator::compute_partial` to ensure
     /// only valid samples are requested
-    fn check_samples(&self, indexes: &Indexes, systems: &mut [&mut dyn System]);
+    fn check_samples(&self, indexes: &Indexes, systems: &mut [Box<dyn System>]);
 
     /// Core implementation of the descriptor.
     ///
@@ -42,7 +42,7 @@ pub trait CalculatorBase: std::panic::RefUnwindSafe {
     /// and features coming from `Descriptor::samples()` and
     /// `Descriptor::features()` respectively; but the user can request only a
     /// subset of them.
-    fn compute(&mut self, systems: &mut [&mut dyn System], descriptor: &mut Descriptor);
+    fn compute(&mut self, systems: &mut [Box<dyn System>], descriptor: &mut Descriptor);
 }
 
 mod sorted_distances;

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -281,7 +281,7 @@ impl CalculatorBase for SphericalExpansion {
         }
     }
 
-    fn check_samples(&self, indexes: &Indexes, systems: &mut [&mut dyn System]) {
+    fn check_samples(&self, indexes: &Indexes, systems: &mut [Box<dyn System>]) {
         assert_eq!(indexes.names(), &["structure", "center", "species_center", "species_neighbor"]);
         // This could be made much faster by not recomputing the full list of
         // potential samples
@@ -293,7 +293,7 @@ impl CalculatorBase for SphericalExpansion {
 
     #[allow(clippy::similar_names, clippy::too_many_lines, clippy::identity_op)]
     #[time_graph::instrument(name = "SphericalExpansion::compute")]
-    fn compute(&mut self, systems: &mut [&mut dyn System], descriptor: &mut Descriptor) {
+    fn compute(&mut self, systems: &mut [Box<dyn System>], descriptor: &mut Descriptor) {
         assert_eq!(descriptor.samples.names(), &["structure", "center", "species_center", "species_neighbor"]);
         assert_eq!(descriptor.features.names(), &["n", "l", "m"]);
 
@@ -479,9 +479,9 @@ mod tests {
             parameters(false)
         )) as Box<dyn CalculatorBase>);
 
-        let mut systems = test_systems(&["water"]);
+        let mut systems = test_systems(&["water"]).boxed();
         let mut descriptor = Descriptor::new();
-        calculator.compute(&mut systems.get(), &mut descriptor, Default::default()).unwrap();
+        calculator.compute(&mut systems, &mut descriptor, Default::default()).unwrap();
 
         assert_eq!(descriptor.samples.names(), ["structure", "center", "species_center", "species_neighbor"]);
         assert_eq!(descriptor.features.names(), ["n", "l", "m"]);
@@ -543,7 +543,7 @@ mod tests {
             parameters(true)
         )) as Box<dyn CalculatorBase>);
 
-        let systems = test_systems(&["water", "methane"]);
+        let mut systems = test_systems(&["water", "methane"]).boxed();
 
         let mut features = IndexesBuilder::new(vec!["n", "l", "m"]);
         features.add(&[v!(0), v!(1), v!(0)]);
@@ -562,7 +562,7 @@ mod tests {
         let samples = samples.finish();
 
         super::super::super::tests_utils::compute_partial(
-            calculator, systems, samples, features, true
+            calculator, &mut systems, samples, features, true
         );
     }
 

--- a/rascaline/src/descriptor/descriptor.rs
+++ b/rascaline/src/descriptor/descriptor.rs
@@ -266,9 +266,9 @@ mod tests {
     fn prepare() {
         let mut descriptor = Descriptor::new();
 
-        let mut systems = test_systems(&["water", "CH"]);
+        let mut systems = test_systems(&["water", "CH"]).boxed();
         let features = dummy_features();
-        let samples = StructureSpeciesSamples.indexes(&mut systems.get());
+        let samples = StructureSpeciesSamples.indexes(&mut systems);
         descriptor.prepare(samples, features);
 
 
@@ -287,9 +287,9 @@ mod tests {
     fn prepare_gradients() {
         let mut descriptor = Descriptor::new();
 
-        let mut systems = test_systems(&["water", "CH"]);
+        let mut systems = test_systems(&["water", "CH"]).boxed();
         let features = dummy_features();
-        let (samples, gradients) = StructureSpeciesSamples.with_gradients(&mut systems.get());
+        let (samples, gradients) = StructureSpeciesSamples.with_gradients(&mut systems);
         descriptor.prepare_gradients(samples, gradients.unwrap(), features);
 
         let gradients = descriptor.gradients.unwrap();
@@ -322,9 +322,9 @@ mod tests {
     fn densify_single_variable() {
         let mut descriptor = Descriptor::new();
 
-        let mut systems = test_systems(&["water", "CH"]);
+        let mut systems = test_systems(&["water", "CH"]).boxed();
         let features = dummy_features();
-        let (samples, gradients) = StructureSpeciesSamples.with_gradients(&mut systems.get());
+        let (samples, gradients) = StructureSpeciesSamples.with_gradients(&mut systems);
         descriptor.prepare_gradients(samples, gradients.unwrap(), features);
 
         descriptor.values.assign(&array![
@@ -402,9 +402,9 @@ mod tests {
     fn densify_multiple_variables() {
         let mut descriptor = Descriptor::new();
 
-        let mut systems = test_systems(&["water", "CH"]);
+        let mut systems = test_systems(&["water", "CH"]).boxed();
         let features = dummy_features();
-        let (samples, gradients) = AtomSpeciesSamples::new(3.0).with_gradients(&mut systems.get());
+        let (samples, gradients) = AtomSpeciesSamples::new(3.0).with_gradients(&mut systems);
         descriptor.prepare_gradients(samples, gradients.unwrap(), features);
 
         descriptor.values.assign(&array![

--- a/rascaline/src/descriptor/indexes/index.rs
+++ b/rascaline/src/descriptor/indexes/index.rs
@@ -281,16 +281,16 @@ impl std::ops::Index<usize> for Indexes {
 pub trait SamplesIndexes {
     fn names(&self) -> Vec<&str>;
 
-    fn indexes(&self, systems: &mut [&mut dyn System]) -> Indexes;
+    fn indexes(&self, systems: &mut [Box<dyn System>]) -> Indexes;
 
-    fn with_gradients(&self, systems: &mut [&mut dyn System]) -> (Indexes, Option<Indexes>) {
+    fn with_gradients(&self, systems: &mut [Box<dyn System>]) -> (Indexes, Option<Indexes>) {
         let indexes = self.indexes(systems);
         let gradients = self.gradients_for(systems, &indexes);
         return (indexes, gradients);
     }
 
     #[allow(unused_variables)]
-    fn gradients_for(&self, systems: &mut [&mut dyn System], samples: &Indexes) -> Option<Indexes> {
+    fn gradients_for(&self, systems: &mut [Box<dyn System>], samples: &Indexes) -> Option<Indexes> {
         None
     }
 }

--- a/rascaline/src/system/test_utils.rs
+++ b/rascaline/src/system/test_utils.rs
@@ -7,12 +7,10 @@ pub struct SimpleSystems {
 }
 
 impl SimpleSystems {
-    pub fn get(&mut self) -> Vec<&mut dyn System> {
-        let mut references = Vec::new();
-        for system in &mut self.systems {
-            references.push(system as &mut dyn System)
-        }
-        return references;
+    pub fn boxed(self) -> Vec<Box<dyn System>> {
+        self.systems.into_iter()
+            .map(|s| Box::new(s) as Box<dyn System>)
+            .collect()
     }
 }
 

--- a/rascaline/tests/data/mod.rs
+++ b/rascaline/tests/data/mod.rs
@@ -4,12 +4,12 @@ use serde_json::Value;
 use ndarray_npy::ReadNpyExt;
 use flate2::read::GzDecoder;
 
-use rascaline::{SimpleSystem, Matrix3, Vector3D};
+use rascaline::{SimpleSystem, System, Matrix3, Vector3D};
 use rascaline::system::UnitCell;
 
 type HyperParameters = String;
 
-pub fn load_calculator_input(path: &str) -> (Vec<SimpleSystem>, HyperParameters) {
+pub fn load_calculator_input(path: &str) -> (Vec<Box<dyn System>>, HyperParameters) {
     let json = std::fs::read_to_string(&format!("tests/data/generated/{}", path))
         .expect("failed to read input file");
 
@@ -36,7 +36,7 @@ pub fn load_calculator_input(path: &str) -> (Vec<SimpleSystem>, HyperParameters)
             simple_system.add_atom(species, position);
         }
 
-        systems.push(simple_system);
+        systems.push(Box::new(simple_system) as Box<dyn System>);
     }
 
     (systems, parameters)

--- a/rascaline/tests/soap-power-spectrum.rs
+++ b/rascaline/tests/soap-power-spectrum.rs
@@ -1,13 +1,12 @@
 use approx::assert_relative_eq;
 use ndarray::Array2;
-use rascaline::{System, Calculator, Descriptor};
+use rascaline::{Calculator, Descriptor};
 
 mod data;
 
 #[test]
 fn values() {
     let (mut systems, parameters) = data::load_calculator_input("soap-power-spectrum-values-input.json");
-    let mut systems = systems.iter_mut().map(|s| s as &mut dyn System).collect::<Vec<_>>();
 
     let mut descriptor = Descriptor::new();
     let mut calculator = Calculator::new("soap_power_spectrum", parameters).unwrap();

--- a/rascaline/tests/spherical-expansion.rs
+++ b/rascaline/tests/spherical-expansion.rs
@@ -1,13 +1,12 @@
 use approx::assert_relative_eq;
 use ndarray::Array2;
-use rascaline::{System, Calculator, Descriptor};
+use rascaline::{Calculator, Descriptor};
 
 mod data;
 
 #[test]
 fn values() {
     let (mut systems, parameters) = data::load_calculator_input("spherical-expansion-values-input.json");
-    let mut systems = systems.iter_mut().map(|s| s as &mut dyn System).collect::<Vec<_>>();
 
     let mut descriptor = Descriptor::new();
     let mut calculator = Calculator::new("spherical_expansion", parameters).unwrap();
@@ -22,7 +21,6 @@ fn values() {
 #[test]
 fn gradients() {
     let (mut systems, parameters) = data::load_calculator_input("spherical-expansion-gradients-input.json");
-    let mut systems = systems.iter_mut().map(|s| s as &mut dyn System).collect::<Vec<_>>();
 
     let mut descriptor = Descriptor::new();
     let mut calculator = Calculator::new("spherical_expansion", parameters).unwrap();


### PR DESCRIPTION
Dealing with Boxed objects is more convenient that references, and this removes a lot of intermediary "references" vector from the C API