### PR TITLE
Use row-major representation for the unit cell matrix

### DIFF
--- a/python/rascaline/systems/ase.py
+++ b/python/rascaline/systems/ase.py
@@ -46,7 +46,7 @@ if HAVE_ASE:
             return self._atoms.positions
 
         def cell(self):
-            return np.concatenate(self._atoms.cell[:, :])
+            return self._atoms.cell[:, :]
 
         def compute_neighbors(self, cutoff):
             if self._last_cutoff == cutoff:

--- a/python/rascaline/systems/base.py
+++ b/python/rascaline/systems/base.py
@@ -84,20 +84,17 @@ class SystemBase:
             """
             self = get_self(user_data)
             cell = np.array(self.cell(), dtype=c_double)
-            if cell.shape == (3, 3):
-                cell = cell.reshape(9)
+            assert cell.shape == (3, 3)
 
-            assert len(cell) == 9
-
-            data[0] = cell[0]
-            data[1] = cell[1]
-            data[2] = cell[2]
-            data[3] = cell[3]
-            data[4] = cell[4]
-            data[5] = cell[5]
-            data[6] = cell[6]
-            data[7] = cell[7]
-            data[8] = cell[8]
+            data[0] = cell[0][0]
+            data[1] = cell[0][1]
+            data[2] = cell[0][2]
+            data[3] = cell[1][0]
+            data[4] = cell[1][1]
+            data[5] = cell[1][2]
+            data[6] = cell[2][0]
+            data[7] = cell[2][1]
+            data[8] = cell[2][2]
 
         struct.cell = struct.cell.__class__(rascal_system_cell)
 
@@ -172,7 +169,9 @@ class SystemBase:
 
     def cell(self):
         """
-        Get the 3x3 matrix representing unit cell of the system.
+        Get the 3x3 matrix representing unit cell of the system. The cell should
+        be written in row major order, i.e. `[[ax, ay, az], [bx, by, bz], [cx,
+        cy, cz]]`, where a/b/c are the unit cell vectors.
         """
         raise NotImplementedError("System.cell method is not implemented")
 

--- a/python/tests/ase_system.py
+++ b/python/tests/ase_system.py
@@ -35,7 +35,7 @@ class TestAseSystem(unittest.TestCase):
         self.assertEqual(self.system.size(), 3)
         self.assertTrue(np.all(self.system.species() == [6, 8, 8]))
         self.assertTrue(np.all(self.system.positions() == self.positions))
-        self.assertTrue(np.all(self.system.cell() == [0, 0, 0, 0, 0, 0, 0, 0, 0]))
+        self.assertTrue(np.all(self.system.cell() == [[0, 0, 0], [0, 0, 0], [0, 0, 0]]))
 
     def test_pairs(self):
         self.system.compute_neighbors(1.5)

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -134,7 +134,8 @@ typedef struct rascal_system_t {
   void (*positions)(const void *user_data, const double **positions);
   /**
    * This function should write the unit cell matrix in `cell`, which have
-   * space for 9 values.
+   * space for 9 values. The cell should be written in row major order, i.e.
+   * `ax ay az bx by bz cx cy cz`, where a/b/c are the unit cell vectors.
    */
   void (*cell)(const void *user_data, double *cell);
   /**

--- a/rascaline-c-api/include/rascaline.hpp
+++ b/rascaline-c-api/include/rascaline.hpp
@@ -83,7 +83,9 @@ public:
     /// on. The array should contain `3 x System::size()` elements.
     virtual const double* positions() const = 0;
 
-    /// Unit cell representation as a 3x3 matrix
+    /// Unit cell representation as a 3x3 matrix. The cell should be written in
+    /// row major order, i.e. `{{ax ay az}, {bx by bz}, {cx cy cz}}`, where
+    /// a/b/c are the unit cell vectors.
     using CellMatrix = std::array<std::array<double, 3>, 3>;
 
     /// Get the matrix describing the unit cell

--- a/rascaline-c-api/src/system.rs
+++ b/rascaline-c-api/src/system.rs
@@ -58,7 +58,8 @@ pub struct rascal_system_t {
     /// cartesian coordinates of the first atom, and so on.
     positions: Option<unsafe extern fn(user_data: *const c_void, positions: *mut *const f64)>,
     /// This function should write the unit cell matrix in `cell`, which have
-    /// space for 9 values.
+    /// space for 9 values. The cell should be written in row major order, i.e.
+    /// `ax ay az bx by bz cx cy cz`, where a/b/c are the unit cell vectors.
     cell: Option<unsafe extern fn(user_data: *const c_void, cell: *mut f64)>,
     /// This function should compute the neighbor list with the given cutoff,
     /// and store it for later access using `pairs` or `pairs_containing`.

--- a/rascaline/src/types/matrix.rs
+++ b/rascaline/src/types/matrix.rs
@@ -684,8 +684,8 @@ mod tests {
             [8.0, 9.0, 10.0],
         ]);
 
-        let vec = Vector3D::new(1.0, 1.0, 1.0);
-        assert_eq!(a * vec, Vector3D::new(6.0, 15.0, 27.0));
+        let vec = Vector3D::new(1.0, 1.5, -2.0);
+        assert_eq!(a * vec, Vector3D::new(-2.0, -0.5, 1.5));
 
         let unit = Matrix3::one();
         let vec = Vector3D::new(567.45, 356.8, 215673.12);


### PR DESCRIPTION
Most of the code already (incorrectly) assumed it, and it is the default in most (non fortran) codes