### PR TITLE
Use Python's chemfiles bindings within Python bindings

### DIFF
--- a/docs/src/reference/python/calculators.rst
+++ b/docs/src/reference/python/calculators.rst
@@ -1,11 +1,15 @@
 Available Calculators
 =====================
 
-.. autoclass:: rascaline.SphericalExpansion
+.. autoclass:: rascaline.SoapPowerSpectrum
+    :show-inheritance:
 
+.. autoclass:: rascaline.SphericalExpansion
+    :show-inheritance:
 
 .. autoclass:: rascaline.SortedDistances
+    :show-inheritance:
 
 
-.. autoclass:: rascaline.calculator.CalculatorBase()
+.. autoclass:: rascaline.calculators.CalculatorBase()
     :members:

--- a/docs/src/reference/python/systems.rst
+++ b/docs/src/reference/python/systems.rst
@@ -5,5 +5,7 @@ Available system implementation
 
 .. autoclass:: rascaline.systems.AseSystem
 
+.. autoclass:: rascaline.systems.ChemfilesSystem
+
 .. autoclass:: rascaline.SystemBase
     :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 legacy_tox_ini = """
 [tox]
 
-[testenv:all]
+[testenv:all-deps]
 # skip install to avoid rebuilding the world, do the install with setup.py
 # instead of pip below
 skip_install = True
@@ -22,12 +22,13 @@ deps =
     discover
     numpy
     ase
+    chemfiles
 
 commands =
     python setup.py --quiet install
     discover -p "*.py" -s python/tests
 
-[testenv:no-ase]
+[testenv:min-deps]
 skip_install = True
 passenv =
     RASCALINE_BUILD_TYPE
@@ -50,9 +51,8 @@ passenv =
     CARGO_HOME
 
 deps =
-    discover
     numpy
-    ase
+    chemfiles
 
 commands =
     python setup.py --quiet install

--- a/python/examples/compute-soap.py
+++ b/python/examples/compute-soap.py
@@ -24,8 +24,8 @@ HYPER_PARAMETERS = {
 
 calculator = SoapPowerSpectrum(**HYPER_PARAMETERS)
 
-# run the actual calculation, use_native_system=True is usually much faster
-descriptor = calculator.compute(frames, use_native_system=True)
+# run the actual calculation
+descriptor = calculator.compute(frames)
 
 # Transform the descriptor to dense representation,
 # with one sample for each atom-centered environment

--- a/python/examples/compute-soap.py
+++ b/python/examples/compute-soap.py
@@ -1,11 +1,11 @@
 import sys
-import ase
-from ase import io
+import chemfiles
 
 from rascaline import SoapPowerSpectrum
 
-# read structures using ASE
-frames = ase.io.read(sys.argv[1], ":")
+# read structures using chemfiles
+with chemfiles.Trajectory(sys.argv[1]) as trajectory:
+    frames = [f for f in trajectory]
 
 # define hyper parameters for the calculation
 HYPER_PARAMETERS = {

--- a/python/rascaline/__init__.py
+++ b/python/rascaline/__init__.py
@@ -6,9 +6,9 @@ from .descriptor import Descriptor
 
 from .systems import SystemBase
 
-from .calculator import CalculatorBase
-from .calculator import SortedDistances
-from .calculator import SphericalExpansion
-from .calculator import SoapPowerSpectrum
+from .calculators import CalculatorBase
+from .calculators import SortedDistances
+from .calculators import SphericalExpansion
+from .calculators import SoapPowerSpectrum
 
 __version__ = "0.0.0"

--- a/python/rascaline/calculators.py
+++ b/python/rascaline/calculators.py
@@ -236,9 +236,6 @@ class SortedDistances(CalculatorBase):
 
     For a full description of the hyper-parameters, see the corresponding
     :ref:`documentation <sorted-distances>`.
-
-    This class inherits from :py:class:`rascaline.calculator.CalculatorBase` and
-    exposes the same functions and properties.
     """
 
     def __init__(self, cutoff, max_neighbors):
@@ -249,16 +246,20 @@ class SortedDistances(CalculatorBase):
 class SphericalExpansion(CalculatorBase):
     """
     The spherical expansion is at the core of representations in the SOAP
-    (Smooth Overlap of Atomic Positions) family. See `this review article
-    <https://doi.org/10.1063/1.5090481>`_ for more information on the SOAP
-    representation, and `this paper <https://doi.org/10.1063/5.0044689>`_ for
-    information on how it is implemented in rascaline.
+    (Smooth Overlap of Atomic Positions) family of descriptors. The spherical
+    expansion represent atomic density as a collection of gaussian functions
+    centered on each atom, and then represent the local density around each atom
+    (up to a cutoff) on a basis of radial functions and spherical harmonics.
+    This representation is not rotationally invariant, for that you should use
+    the :py:class:`SoapPowerSpectrum` class.
+
+    See `this review article <https://doi.org/10.1063/1.5090481>`_ for more
+    information on the SOAP representation, and `this paper
+    <https://doi.org/10.1063/5.0044689>`_ for information on how it is
+    implemented in rascaline.
 
     For a full description of the hyper-parameters, see the corresponding
     :ref:`documentation <spherical-expansion>`.
-
-    This class inherits from :py:class:`rascaline.calculator.CalculatorBase` and
-    exposes the same functions and properties.
     """
 
     def __init__(
@@ -284,6 +285,21 @@ class SphericalExpansion(CalculatorBase):
 
 
 class SoapPowerSpectrum(CalculatorBase):
+    """
+    The SOAP power spectrum is the main member of the SOAP (Smooth Overlap of
+    Atomic Positions) family of descriptors. The power spectrum is based on the
+    :py:class:`SphericalExpansion` coefficients, which are combined to create a
+    rotationally invariant three-body descriptor.
+
+    See `this review article <https://doi.org/10.1063/1.5090481>`_ for more
+    information on the SOAP representation, and `this paper
+    <https://doi.org/10.1063/5.0044689>`_ for information on how it is
+    implemented in rascaline.
+
+    For a full description of the hyper-parameters, see the corresponding
+    :ref:`documentation <soap-power-spectrum>`.
+    """
+
     def __init__(
         self,
         cutoff,

--- a/python/rascaline/systems/__init__.py
+++ b/python/rascaline/systems/__init__.py
@@ -1,31 +1,35 @@
 from .base import SystemBase
-from .ase import AseSystem
+from .ase import AseSystem, HAVE_ASE
+from .chemfiles import ChemfilesSystem, HAVE_CHEMFILES
 
 
 def wrap_system(system):
     """
     This function is automatically called on all systems passed to
-    :py:func:`rascaline.calculator.CalculatorBase.compute`. It wraps different
+    :py:func:`rascaline.calculators.CalculatorBase.compute`. It wraps different
     systems implementation into the right class to make them compatible with
     rascaline. The following system types are supported:
 
     - `ase.Atoms`_: the Atomistic Simulation Environment Atoms class
+    - `chemfiles.Frame`_: chemfiles' Frame type
+
+    If ``system`` is already a subclass of :py:class:`rascaline.SystemBase`, it
+    is returned as-is.
 
     :param system: external system of one of the above type
 
     :returns: a specialized instance of :py:class:`rascaline.SystemBase`
 
     .. _ase.Atoms: https://wiki.fysik.dtu.dk/ase/ase/atoms.html
+    .. _chemfiles.Frame: http://chemfiles.org/chemfiles.py/latest/reference/frame.html
     """
     if isinstance(system, SystemBase):
         return system
 
-    try:
-        import ase
+    if HAVE_ASE and AseSystem.can_wrap(system):
+        return AseSystem(system)
 
-        if isinstance(system, ase.Atoms):
-            return AseSystem(system)
-    except ImportError:
-        pass
+    if HAVE_CHEMFILES and ChemfilesSystem.can_wrap(system):
+        return ChemfilesSystem(system)
 
     raise TypeError(f"unknown system type: {type(system)}")

--- a/python/rascaline/systems/ase.py
+++ b/python/rascaline/systems/ase.py
@@ -12,103 +12,100 @@ except ImportError:
 
 from .base import SystemBase
 
-if HAVE_ASE:
 
-    class AseSystem(SystemBase):
+class AseSystem(SystemBase):
+    """
+    This class implements :py:class:`rascaline.SystemBase` using the
+    `ase.Atoms`_ to get the data and `ase.neighborlist.neighbor_list`_ to
+    compute the neighbor list.
+
+    .. _ase.Atoms: https://wiki.fysik.dtu.dk/ase/ase/atoms.html
+
+    .. _ase.neighborlist.neighbor_list:
+        https://wiki.fysik.dtu.dk/ase/ase/neighborlist.html#ase.neighborlist.neighbor_list
+    """
+
+    @staticmethod
+    def can_wrap(o):
+        return isinstance(o, ase.Atoms)
+
+    def __init__(self, atoms):
         """
-        This class implements :py:class:`rascaline.SystemBase` using the
-        `ase.Atoms`_ to get the data and `ase.neighborlist.neighbor_list`_ to
-        compute the neighbor list.
-
-        .. _ase.Atoms: https://wiki.fysik.dtu.dk/ase/ase/atoms.html
-
-        .. _ase.neighborlist.neighbor_list:
-            https://wiki.fysik.dtu.dk/ase/ase/neighborlist.html#ase.neighborlist.neighbor_list
+        :param atoms: `ase.Atoms`_ object to be wrapped in this ``AseSystem``
         """
+        super().__init__()
+        if not isinstance(atoms, ase.Atoms):
+            raise Exception("this class expects ASE.Atoms objects")
 
-        def __init__(self, atoms):
-            """
-            :param atoms: `ase.Atoms`_ object to be wrapped in this ``AseSystem``
-            """
-            super().__init__()
-            if not isinstance(atoms, ase.Atoms):
-                raise Exception("this class expects ASE.Atoms objects")
+        # normalize pbc to three values
+        if isinstance(atoms.pbc, bool):
+            atoms_pbc = [atoms.pbc, atoms.pbc, atoms.pbc]
+        else:
+            atoms_pbc = copy.deepcopy(atoms.pbc)
 
-            # normalize pbc to three values
-            if isinstance(atoms.pbc, bool):
-                atoms_pbc = [atoms.pbc, atoms.pbc, atoms.pbc]
+        self._cell = np.array(atoms.cell)
+        # validate pcb consistency with the cell matrix
+        if np.all(np.abs(self._cell) < 1e-9):
+            if np.any(atoms_pbc):
+                raise Exception(
+                    "periodic boundary conditions are enabled, "
+                    "but the cell matrix is zero everywhere. "
+                    "You should set pbc to `False`, or the cell to its value."
+                )
+        elif np.any(np.bitwise_not(atoms_pbc)):
+            if np.all(np.bitwise_not(atoms_pbc)):
+                warnings.warn(
+                    "periodic boundary conditions are disabled, but the cell "
+                    "matrix is not zero, we will set the cell to zero."
+                )
+                self._cell[:, :] = 0.0
             else:
-                atoms_pbc = copy.deepcopy(atoms.pbc)
+                raise Exception(
+                    "different periodic boundary conditions on different axis "
+                    "are not supported"
+                )
 
-            self._cell = np.array(atoms.cell)
-            # validate pcb consistency with the cell matrix
-            if np.all(np.abs(self._cell) < 1e-9):
-                if np.any(atoms_pbc):
-                    raise Exception(
-                        "periodic boundary conditions are enabled, "
-                        "but the cell matrix is zero everywhere. "
-                        "You should set pbc to `False`, or the cell to its value."
-                    )
-            elif np.any(np.bitwise_not(atoms_pbc)):
-                if np.all(np.bitwise_not(atoms_pbc)):
-                    warnings.warn(
-                        "periodic boundary conditions are disabled, but the cell "
-                        "matrix is not zero, we will set the cell to zero."
-                    )
-                    self._cell[:, :] = 0.0
-                else:
-                    raise Exception(
-                        "different periodic boundary conditions on different axis "
-                        "are not supported"
-                    )
+        self._atoms = atoms
+        self._pairs = []
+        self._pairs_by_center = []
+        self._last_cutoff = None
 
-            self._atoms = atoms
-            self._pairs = []
-            self._pairs_by_center = []
-            self._last_cutoff = None
+    def size(self):
+        return len(self._atoms)
 
-        def size(self):
-            return len(self._atoms)
+    def species(self):
+        return self._atoms.numbers
 
-        def species(self):
-            return self._atoms.numbers
+    def positions(self):
+        return self._atoms.positions
 
-        def positions(self):
-            return self._atoms.positions
+    def cell(self):
+        return self._cell
 
-        def cell(self):
-            return self._cell
+    def compute_neighbors(self, cutoff):
+        if self._last_cutoff == cutoff:
+            return
 
-        def compute_neighbors(self, cutoff):
-            if self._last_cutoff == cutoff:
-                return
+        self._pairs = []
 
-            self._pairs = []
+        nl_result = neighborlist.neighbor_list("ijdD", self._atoms, cutoff)
+        for (i, j, d, D) in zip(*nl_result):
+            if j < i:
+                # we want a half neighbor list, so drop all duplicated
+                # neighbors
+                continue
+            self._pairs.append((i, j, d, D))
 
-            nl_result = neighborlist.neighbor_list("ijdD", self._atoms, cutoff)
-            for (i, j, d, D) in zip(*nl_result):
-                if j < i:
-                    # we want a half neighbor list, so drop all duplicated
-                    # neighbors
-                    continue
-                self._pairs.append((i, j, d, D))
+        self._pairs_by_center = []
+        for _ in range(self.size()):
+            self._pairs_by_center.append([])
 
-            self._pairs_by_center = []
-            for _ in range(self.size()):
-                self._pairs_by_center.append([])
+        for (i, j, d, D) in self._pairs:
+            self._pairs_by_center[i].append((i, j, d, D))
+            self._pairs_by_center[j].append((i, j, d, D))
 
-            for (i, j, d, D) in self._pairs:
-                self._pairs_by_center[i].append((i, j, d, D))
-                self._pairs_by_center[j].append((i, j, d, D))
+    def pairs(self):
+        return self._pairs
 
-        def pairs(self):
-            return self._pairs
-
-        def pairs_containing(self, center):
-            return self._pairs_by_center[center]
-
-
-else:
-
-    class AseSystem(SystemBase):
-        pass
+    def pairs_containing(self, center):
+        return self._pairs_by_center[center]

--- a/python/rascaline/systems/base.py
+++ b/python/rascaline/systems/base.py
@@ -25,7 +25,8 @@ class SystemBase:
     implement this class to add new kinds of system that work with rascaline.
 
     Most users should use one of the already provided implementation, such as
-    :py:class:`rascaline.systems.AseSystem` instead of using this class
+    :py:class:`rascaline.systems.AseSystem` or
+    :py:class:`rascaline.systems.ChemfilesSystem` instead of using this class
     directly.
     """
 

--- a/python/rascaline/systems/chemfiles.py
+++ b/python/rascaline/systems/chemfiles.py
@@ -1,0 +1,103 @@
+import warnings
+import numpy as np
+
+try:
+    import chemfiles
+
+    if not chemfiles.__version__.startswith("0.10"):
+        warnings.warn(
+            "found chemfiles, but the version is not supported: "
+            + "we need chemfiles v0.10."
+        )
+        HAVE_CHEMFILES = False
+    else:
+        HAVE_CHEMFILES = True
+except ImportError:
+    HAVE_CHEMFILES = False
+
+from .base import SystemBase
+from .._rascaline import c_uintptr_t
+
+
+# global cache of species number for atoms outside of the periodic table
+SPECIES_CACHE = {}
+
+
+def get_species_for_non_element(name):
+    """
+    Get a species number to associate with an atom which is not inside the
+    periodic table.
+    """
+    if name in SPECIES_CACHE:
+        return SPECIES_CACHE[name]
+    else:
+        # start at 120 since that more atoms that are in the periodic table
+        species = 120 + len(SPECIES_CACHE)
+        SPECIES_CACHE[name] = species
+        return species
+
+
+class ChemfilesSystem(SystemBase):
+    """
+    This class implements :py:class:`rascaline.SystemBase` wrapping a
+    `chemfiles.Frame`_. Since chemfiles does not offer a neighbors list, this
+    implementation of system can only be used with ``use_native_system=True`` in
+    :py:func:`rascaline.calculators.CalculatorBase.compute`.
+
+    Atomic species are assigned as the atomic number if the atom ``type`` is one
+    of the periodic table elements; or as a value above 120 if the atom type is
+    not in the periodic table.
+
+    .. _chemfiles.Frame: http://chemfiles.org/chemfiles.py/latest/reference/frame.html
+    """
+
+    @staticmethod
+    def can_wrap(o):
+        return isinstance(o, chemfiles.Frame)
+
+    def __init__(self, frame):
+        """
+        :param frame: `chemfiles.Frame`_ object to be wrapped in this
+            ``ChemfilesSystem``
+
+        """
+        super().__init__()
+        if not isinstance(frame, chemfiles.Frame):
+            raise Exception("this class expects chemfiles.Frame objects")
+
+        self._frame = frame
+        self._species = np.zeros((self.size()), dtype=c_uintptr_t)
+        for i, atom in enumerate(self._frame.atoms):
+            if atom.atomic_number != 0:
+                self._species[i] = atom.atomic_number
+            else:
+                self._species[i] = get_species_for_non_element(atom.type)
+
+    def size(self):
+        return len(self._frame.atoms)
+
+    def species(self):
+        return self._species
+
+    def positions(self):
+        return self._frame.positions
+
+    def cell(self):
+        # we need to transpose the cell since chemfiles stores it in column
+        # major format
+        return self._frame.cell.matrix.T
+
+    def compute_neighbors(self, cutoff):
+        raise Exception(
+            "chemfiles systems can only be used with 'use_native_system=True'"
+        )
+
+    def pairs(self):
+        raise Exception(
+            "chemfiles systems can only be used with 'use_native_system=True'"
+        )
+
+    def pairs_containing(self, center):
+        raise Exception(
+            "chemfiles systems can only be used with 'use_native_system=True'"
+        )

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from rascaline import SortedDistances
-from rascaline.calculator import DummyCalculator
+from rascaline.calculators import DummyCalculator
 
 from test_systems import TestSystem
 

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -44,7 +44,7 @@ class TestDummyCalculator(unittest.TestCase):
     def test_compute(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         values = descriptor.values
         self.assertEqual(values.shape, (4, 2))
@@ -61,18 +61,20 @@ class TestDummyCalculator(unittest.TestCase):
     def test_compute_multiple_systems(self):
         systems = [TestSystem(), TestSystem(), TestSystem()]
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
-        descriptor = calculator.compute(systems)
+        descriptor = calculator.compute(systems, use_native_system=False)
 
         self.assertEqual(descriptor.values.shape, (12, 2))
 
     def test_compute_partial_samples(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         # From a selection scheme, using numpy array indexing
         samples = descriptor.samples[[0, 2]]
-        descriptor = calculator.compute(system, selected_samples=samples)
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_samples=samples
+        )
 
         values = descriptor.values
         self.assertEqual(values.shape, (2, 2))
@@ -86,7 +88,9 @@ class TestDummyCalculator(unittest.TestCase):
 
         #  Manually constructing the selected samples
         samples = [(0, 0), (0, 3), (0, 1)]
-        descriptor = calculator.compute(system, selected_samples=samples)
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_samples=samples
+        )
 
         values = descriptor.values
         self.assertEqual(values.shape, (3, 2))
@@ -102,11 +106,13 @@ class TestDummyCalculator(unittest.TestCase):
     def test_compute_partial_features(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         # From a selection scheme, using numpy array indexing
         features = descriptor.features[[1]]
-        descriptor = calculator.compute(system, selected_features=features)
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_features=features
+        )
 
         values = descriptor.values
         self.assertEqual(values.shape, (4, 1))
@@ -122,7 +128,9 @@ class TestDummyCalculator(unittest.TestCase):
 
         # Manually constructing the selected features
         features = [[1, 0]]
-        descriptor = calculator.compute(system, selected_features=features)
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_features=features
+        )
 
         values = descriptor.values
         self.assertEqual(values.shape, (4, 1))

--- a/python/tests/descriptor.py
+++ b/python/tests/descriptor.py
@@ -34,7 +34,7 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_values(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         values = descriptor.values
         self.assertEqual(values.shape, (4, 2))
@@ -51,16 +51,16 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_gradients(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
         self.assertEqual(descriptor.gradients, None)
 
         system = EmptySystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
         self.assertEqual(descriptor.gradients.shape, (0, 2))
 
         system = TestSystem()
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
         gradients = descriptor.gradients
         self.assertEqual(gradients.shape, (18, 2))
         for i in range(18):
@@ -72,7 +72,7 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_samples(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         samples = descriptor.samples
         self.assertEqual(len(samples), 4)
@@ -95,11 +95,11 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_gradient_indexes(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
         self.assertEqual(len(descriptor.gradients_samples), 0)
 
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
         gradients_samples = descriptor.gradients_samples
         self.assertEqual(len(gradients_samples), 18)
 
@@ -147,7 +147,7 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_features(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=False)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         features = descriptor.features
         self.assertEqual(len(features), 2)
@@ -168,7 +168,7 @@ class TestDummyDescriptor(unittest.TestCase):
     def test_densify(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=12, name="", gradients=True)
-        descriptor = calculator.compute(system)
+        descriptor = calculator.compute(system, use_native_system=False)
 
         self.assertEqual(descriptor.values.shape, (4, 2))
         self.assertEqual(descriptor.gradients.shape, (18, 2))

--- a/python/tests/descriptor.py
+++ b/python/tests/descriptor.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from rascaline import Descriptor
-from rascaline.calculator import DummyCalculator
+from rascaline.calculators import DummyCalculator
 
 from test_systems import TestSystem, EmptySystem
 

--- a/python/tests/log.py
+++ b/python/tests/log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from rascaline.calculator import DummyCalculator
+from rascaline.calculators import DummyCalculator
 
 from rascaline import set_logging_callback
 from rascaline.log import default_logging_callback

--- a/python/tests/systems/ase.py
+++ b/python/tests/systems/ase.py
@@ -2,23 +2,17 @@
 import unittest
 import numpy as np
 
-from rascaline.systems import AseSystem
+from rascaline.systems import AseSystem, HAVE_ASE
 
 try:
     import ase
-
-    HAVE_ASE = True
 except ImportError:
-    HAVE_ASE = False
+    pass
 
 
-@unittest.skipIf(not HAVE_ASE, "ASE not installed")
+@unittest.skipIf(not HAVE_ASE, "ASE is not installed")
 class TestAseSystem(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not HAVE_ASE:
-            return
-
+    def setUp(self):
         self.positions = [
             (0, 0, 0),
             (0, 0, 1.4),
@@ -101,7 +95,7 @@ class TestAseSystem(unittest.TestCase):
         self.assertEqual(pairs[1][:2], (1, 2))
 
 
-@unittest.skipIf(not HAVE_ASE, "ASE not installed")
+@unittest.skipIf(not HAVE_ASE, "ASE is not installed")
 class TestAseSystemErrors(unittest.TestCase):
     def test_pbc_no_cell(self):
         message = (

--- a/python/tests/systems/chemfiles.py
+++ b/python/tests/systems/chemfiles.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+import unittest
+import numpy as np
+from rascaline.status import RascalError
+
+from rascaline.systems import ChemfilesSystem, HAVE_CHEMFILES
+from rascaline.calculators import DummyCalculator
+
+try:
+    import chemfiles
+except ImportError:
+    pass
+
+
+@unittest.skipIf(not HAVE_CHEMFILES, "chemfiles is not installed")
+class TestChemfilesSystem(unittest.TestCase):
+    def test_system_implementation(self):
+        frame = chemfiles.Frame()
+        frame.add_atom(chemfiles.Atom("C"), (0, 0, 0))
+        frame.add_atom(chemfiles.Atom("CH3"), (0, 1, 0))
+        frame.add_atom(chemfiles.Atom("X"), (0, 2, 0))
+        frame.add_atom(chemfiles.Atom("Zn1", "Zn"), (0, 3, 0))
+
+        system = ChemfilesSystem(frame)
+
+        self.assertEqual(system.size(), 4)
+        self.assertTrue(np.all(system.species() == [6, 120, 121, 30]))
+        positions = [
+            (0, 0, 0),
+            (0, 1, 0),
+            (0, 2, 0),
+            (0, 3, 0),
+        ]
+        self.assertTrue(np.all(system.positions() == positions))
+
+    def test_cell(self):
+        frame = chemfiles.Frame()
+
+        system = ChemfilesSystem(frame)
+        self.assertTrue(np.all(system.cell() == 0))
+
+        frame.cell = chemfiles.UnitCell((3, 3, 3))
+        self.assertTrue(np.allclose(system.cell(), np.diag([3, 3, 3])))
+
+        frame.cell = chemfiles.UnitCell((3, 3, 3), (60, 60, 60))
+        expected = [
+            [3.0, 0.0, 0.0],
+            [1.5, 2.59807621, 0.0],
+            [1.5, 0.8660254, 2.44948974],
+        ]
+        self.assertTrue(np.allclose(system.cell(), expected))
+
+    def test_compute(self):
+        frame = chemfiles.Frame()
+        frame.add_atom(chemfiles.Atom("C"), (0, 0, 0))
+        frame.add_atom(chemfiles.Atom("C"), (0, 1, 0))
+        frame.add_atom(chemfiles.Atom("C"), (0, 2, 0))
+        frame.add_atom(chemfiles.Atom("C"), (0, 3, 0))
+
+        calculator = DummyCalculator(cutoff=3.4, delta=1, name="", gradients=False)
+
+        with self.assertRaises(RascalError) as cm:
+            calculator.compute(frame, use_native_system=False)
+
+        self.assertEqual(
+            cm.exception.__cause__.args[0],
+            "chemfiles systems can only be used with 'use_native_system=True'",
+        )
+
+        # use_native_system=True should work fine
+        descriptor = calculator.compute(frame, use_native_system=True)
+        self.assertEqual(descriptor.values.shape, (4, 2))

--- a/python/tests/systems/errors.py
+++ b/python/tests/systems/errors.py
@@ -16,7 +16,7 @@ class TestSystemExceptions(unittest.TestCase):
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
 
         with self.assertRaises(RascalError) as cm:
-            _ = calculator.compute(system)
+            _ = calculator.compute(system, use_native_system=False)
 
         self.assertEqual(
             cm.exception.args[0],

--- a/python/tests/systems/errors.py
+++ b/python/tests/systems/errors.py
@@ -3,7 +3,7 @@ import unittest
 
 from rascaline import RascalError
 from rascaline.systems import SystemBase
-from rascaline.calculator import DummyCalculator
+from rascaline.calculators import DummyCalculator
 
 
 class UnimplementedSystem(SystemBase):

--- a/python/tests/test_systems.py
+++ b/python/tests/test_systems.py
@@ -17,7 +17,7 @@ class TestSystem(SystemBase):
         return [[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3]]
 
     def cell(self):
-        return [10, 0, 0, 0, 10, 0, 0, 0, 10]
+        return [[10, 0, 0], [0, 10, 0], [0, 0, 10]]
 
     def compute_neighbors(self, cutoff):
         return

--- a/rascaline/src/calculators/dummy_calculator.rs
+++ b/rascaline/src/calculators/dummy_calculator.rs
@@ -71,7 +71,7 @@ impl CalculatorBase for DummyCalculator {
         Ok(())
     }
 
-    #[allow(clippy::clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss)]
     #[time_graph::instrument(name = "DummyCalculator::compute")]
     fn compute(&mut self, systems: &mut [Box<dyn System>], descriptor: &mut Descriptor) -> Result<(), Error> {
         if self.name.contains("log-test-info:") {

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,18 @@ class cargo_ext(build_ext):
         else:
             raise ImportError("Unknown platform. Please edit this file")
 
-        cargo_build = ["cargo", "build"]
+        cargo_build = [
+            "cargo",
+            "build",
+            # do not include chemfiles when building the Python package
+            "--no-default-features",
+        ]
         if RASCALINE_BUILD_TYPE == "release":
             cargo_build.append("--release")
 
-        process = subprocess.Popen(cargo_build, cwd=ROOT)
+        process = subprocess.Popen(
+            cargo_build, cwd=os.path.join(ROOT, "rascaline-c-api")
+        )
         status = process.wait()
         if status != 0:
             sys.exit(status)


### PR DESCRIPTION
Instead of using the Rust bindings through `BasicSystem`, make chemfiles' frames usable directly as a `System`. This should give users more flexibility.