### PR TITLE
Enable building the C API as a static library

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} / rust ${{ matrix.rust-version }} / ${{ matrix.build-type }}
+    name: ${{ matrix.os }} / rust ${{ matrix.rust-version }} / ${{ matrix.build-type }} ${{ matrix.extra-name }}
     container: ${{ matrix.container }}
     strategy:
       matrix:
@@ -18,6 +18,12 @@ jobs:
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
+          - os: ubuntu-18.04
+            rust-version: stable
+            rust-target: x86_64-unknown-linux-gnu
+            build-type: debug
+            test-static-lib: true
+            extra-name: static C library
           - os: ubuntu-18.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
@@ -76,6 +82,8 @@ jobs:
 
       - name: run tests
         if: matrix.build-type == 'debug'
+        env:
+          RASCALINE_TEST_WITH_STATIC_LIB: ${{ matrix.test-static-lib || 0 }}
         run: cargo test --target ${{ matrix.rust-target }} -- --test-threads=2
 
       - name: run tests in release mode

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -6,10 +6,11 @@ string(REGEX REPLACE ".*version = \"([0-9]+\\.[0-9]+\\.[0-9]+)\".*" "\\1" RASCAL
 
 project(rascaline
     VERSION ${RASCALINE_VERSION}
-    LANGUAGES C
+    LANGUAGES C # we need to declare a language to access CMAKE_SIZEOF_VOID_P later
 )
 
 option(RASCAL_DISABLE_CHEMFILES "Disable the usage of chemfiles for reading structures from files" OFF)
+option(BUILD_SHARED_LIBS "Build a shared library instead of a static one" ON)
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     if("${CMAKE_BUILD_TYPE}" STREQUAL "" AND "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
@@ -81,16 +82,23 @@ file(GLOB_RECURSE ALL_RUST_SOURCES
     ${PROJECT_SOURCE_DIR}/src/**.rs
 )
 
-set(RASCALINE_LOCATION "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}/${CMAKE_SHARED_LIBRARY_PREFIX}rascaline${CMAKE_SHARED_LIBRARY_SUFFIX}")
-get_filename_component(RASCALINE_LIB_NAME ${RASCALINE_LOCATION} NAME)
+set(RASCALINE_LIBDIR "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}/")
+if(${BUILD_SHARED_LIBS})
+    add_library(rascaline SHARED IMPORTED GLOBAL)
+    set(RASCALINE_LOCATION "${RASCALINE_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rascaline${CMAKE_SHARED_LIBRARY_SUFFIX}")
+else()
+    add_library(rascaline STATIC IMPORTED GLOBAL)
+    set(RASCALINE_LOCATION "${RASCALINE_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}rascaline${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
 
+get_filename_component(RASCALINE_LIB_NAME ${RASCALINE_LOCATION} NAME)
 add_custom_target(cargo-build-rascaline ALL
     COMMAND cargo build ${CARGO_BUILD_ARG}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS ${ALL_RUST_SOURCES}
+    COMMENT "Building ${RASCALINE_LIB_NAME} with cargo"
 )
 
-add_library(rascaline SHARED IMPORTED GLOBAL)
 add_dependencies(rascaline cargo-build-rascaline)
 set(RASCALINE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/rascaline.h"
@@ -102,6 +110,24 @@ set_target_properties(rascaline PROPERTIES
     IMPORTED_LOCATION ${RASCALINE_LOCATION}
     INTERFACE_INCLUDE_DIRECTORIES ${RASCALINE_INCLUDE_DIR}
 )
+
+if(NOT ${RASCAL_DISABLE_CHEMFILES})
+    # the static library will need to be linked as C++ code since it contains
+    # chemfiles
+    set_target_properties(rascaline PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES CXX
+    )
+endif()
+
+if(UNIX AND NOT APPLE)
+    set(LINUX TRUE)
+endif()
+
+if(LINUX)
+    set_target_properties(rascaline PROPERTIES
+        IMPORTED_LINK_INTERFACE_LIBRARIES "pthread;dl"
+    )
+endif()
 
 #------------------------------------------------------------------------------#
 # Installation configuration

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2018"
 
 [lib]
 name = "rascaline"
-crate-type = ["cdylib"]
+# when https://github.com/rust-lang/cargo/pull/8789 lands, use it here!
+# until then, build all the crate-type we need
+crate-type = ["cdylib", "staticlib"]
 bench = false
 
 [features]

--- a/rascaline-c-api/tests/c-api.rs
+++ b/rascaline-c-api/tests/c-api.rs
@@ -26,10 +26,19 @@ fn check_c_api() {
         "release"
     };
 
+    let mut shared_lib = "ON";
+    if let Ok(value) = std::env::var("RASCALINE_TEST_WITH_STATIC_LIB") {
+        if value != "0" {
+            shared_lib = "OFF";
+        }
+    }
+
     let mut cmake_config = Command::new("cmake");
     cmake_config.current_dir(&build_dir);
     cmake_config.arg(&source_dir);
     cmake_config.arg(format!("-DCMAKE_BUILD_TYPE={}", build_type));
+    cmake_config.arg(format!("-DBUILD_SHARED_LIBS={}", shared_lib));
+
     let status = cmake_config.status().expect("failed to configure cmake");
     assert!(status.success());
 


### PR DESCRIPTION
This is usually easier to integrate with other C/C++ projects