### PR TITLE
Rename AtomSpeciesSamples to TwoBodiesSpeciesSamples

### DIFF
--- a/rascaline/src/calculators/soap/power_spectrum.rs
+++ b/rascaline/src/calculators/soap/power_spectrum.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 
-use crate::descriptor::{ThreeBodiesSpeciesSamples, AtomSpeciesSamples, SamplesIndexes, IndexValue, Indexes, IndexesBuilder};
+use crate::descriptor::{SamplesIndexes, IndexValue, Indexes, IndexesBuilder};
+use crate::descriptor::{TwoBodiesSpeciesSamples, ThreeBodiesSpeciesSamples};
+
 use crate::{CalculationOptions, Calculator, SelectedIndexes};
 use crate::{Descriptor, Error, System};
 
@@ -93,7 +95,7 @@ impl SoapPowerSpectrum {
         }
 
         let mut spherical_expansion_samples = IndexesBuilder::new(
-            AtomSpeciesSamples::new(1.0).names()
+            TwoBodiesSpeciesSamples::new(1.0).names()
         );
         for index in set {
             spherical_expansion_samples.add(&index);

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -1,6 +1,6 @@
 use ndarray::Array2;
 
-use crate::descriptor::{IndexesBuilder, IndexValue, Indexes, SamplesIndexes, AtomSpeciesSamples};
+use crate::descriptor::{IndexesBuilder, IndexValue, Indexes, SamplesIndexes, TwoBodiesSpeciesSamples};
 use crate::{Descriptor, Error, System, Vector3D};
 
 use super::super::CalculatorBase;
@@ -511,7 +511,7 @@ impl CalculatorBase for SphericalExpansion {
     }
 
     fn samples(&self) -> Box<dyn SamplesIndexes> {
-        Box::new(AtomSpeciesSamples::with_self_contribution(self.parameters.cutoff))
+        Box::new(TwoBodiesSpeciesSamples::with_self_contribution(self.parameters.cutoff))
     }
 
     fn compute_gradients(&self) -> bool {

--- a/rascaline/src/calculators/sorted_distances.rs
+++ b/rascaline/src/calculators/sorted_distances.rs
@@ -5,7 +5,7 @@ use ndarray::{aview1, s};
 use super::CalculatorBase;
 
 use crate::descriptor::{Indexes, IndexesBuilder, IndexValue};
-use crate::descriptor::{SamplesIndexes, AtomSpeciesSamples};
+use crate::descriptor::{SamplesIndexes, TwoBodiesSpeciesSamples};
 use crate::{Descriptor, Error, System};
 
 #[derive(Debug, Clone)]
@@ -49,7 +49,7 @@ impl CalculatorBase for SortedDistances {
     }
 
     fn samples(&self) -> Box<dyn SamplesIndexes> {
-        Box::new(AtomSpeciesSamples::new(self.cutoff))
+        Box::new(TwoBodiesSpeciesSamples::new(self.cutoff))
     }
 
     fn compute_gradients(&self) -> bool {

--- a/rascaline/src/descriptor/descriptor.rs
+++ b/rascaline/src/descriptor/descriptor.rs
@@ -274,7 +274,7 @@ fn remove_from_samples(samples: &Indexes, variables: &[&str]) -> RemovedSampleRe
 mod tests {
     use super::*;
     use crate::systems::test_systems;
-    use crate::descriptor::{AtomSpeciesSamples, StructureSpeciesSamples, SamplesIndexes};
+    use crate::descriptor::{TwoBodiesSpeciesSamples, StructureSpeciesSamples, SamplesIndexes};
     use ndarray::array;
 
     fn dummy_features() -> Indexes {
@@ -434,7 +434,7 @@ mod tests {
 
         let mut systems = test_systems(&["water"]).boxed();
         let features = dummy_features();
-        let (samples, gradients) = AtomSpeciesSamples::new(3.0).with_gradients(&mut systems).unwrap();
+        let (samples, gradients) = TwoBodiesSpeciesSamples::new(3.0).with_gradients(&mut systems).unwrap();
         descriptor.prepare_gradients(samples, gradients.unwrap(), features);
 
         descriptor.values.assign(&array![

--- a/rascaline/src/descriptor/indexes/mod.rs
+++ b/rascaline/src/descriptor/indexes/mod.rs
@@ -7,5 +7,6 @@ mod samples;
 pub use self::samples::{StructureSamples, AtomSamples};
 
 mod species;
-pub use self::species::{StructureSpeciesSamples, AtomSpeciesSamples};
-pub use self::species::{ThreeBodiesSpeciesSamples};
+pub use self::species::StructureSpeciesSamples;
+pub use self::species::TwoBodiesSpeciesSamples;
+pub use self::species::ThreeBodiesSpeciesSamples;

--- a/rascaline/src/descriptor/indexes/species/mod.rs
+++ b/rascaline/src/descriptor/indexes/species/mod.rs
@@ -1,8 +1,8 @@
 mod structure;
 pub use self::structure::StructureSpeciesSamples;
 
-mod atom;
-pub use self::atom::AtomSpeciesSamples;
+mod two_bodies;
+pub use self::two_bodies::TwoBodiesSpeciesSamples;
 
 mod three_bodies;
 pub use self::three_bodies::ThreeBodiesSpeciesSamples;

--- a/rascaline/src/descriptor/indexes/species/structure.rs
+++ b/rascaline/src/descriptor/indexes/species/structure.rs
@@ -69,7 +69,7 @@ mod tests {
     }
 
     #[test]
-    fn structure() {
+    fn samples() {
         let mut systems = test_systems(&["methane", "methane", "water"]).boxed();
         let indexes = StructureSpeciesSamples.indexes(&mut systems).unwrap();
         assert_eq!(indexes.count(), 6);
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn structure_gradient() {
+    fn gradients() {
         let mut systems = test_systems(&["CH", "water"]).boxed();
         let (_, gradients) = StructureSpeciesSamples.with_gradients(&mut systems).unwrap();
         let gradients = gradients.unwrap();
@@ -103,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_structure_gradient() {
+    fn partial_gradients() {
         let mut indexes = IndexesBuilder::new(vec!["structure", "species"]);
         indexes.add(&[v!(2), v!(1)]);
         indexes.add(&[v!(0), v!(6)]);

--- a/rascaline/src/descriptor/indexes/species/three_bodies.rs
+++ b/rascaline/src/descriptor/indexes/species/three_bodies.rs
@@ -255,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies() {
+    fn samples() {
         let mut systems = test_systems(&["CH", "water"]).boxed();
         let strategy = ThreeBodiesSpeciesSamples::new(2.0);
         let indexes = strategy.indexes(&mut systems).unwrap();
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_gradients() {
+    fn gradients() {
         let mut systems = test_systems(&["water"]).boxed();
         let strategy = ThreeBodiesSpeciesSamples::new(2.0);
         let (_, gradients) = strategy.with_gradients(&mut systems).unwrap();
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_partial_gradients() {
+    fn partial_gradients() {
         let mut indexes = IndexesBuilder::new(vec!["structure", "center", "species_center", "species_neighbor_1", "species_neighbor_2"]);
         indexes.add(&[v!(0), v!(1), v!(6), v!(1), v!(1)]);
         indexes.add(&[v!(1), v!(1), v!(1), v!(123456), v!(123456)]);
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_self_contribution() {
+    fn self_contribution() {
         let mut systems = test_systems(&["water"]).boxed();
         // Only include O-H neighbors
         let strategy = ThreeBodiesSpeciesSamples::with_self_contribution(1.2);
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_self_contribution_no_neighbor() {
+    fn self_contribution_no_neighbor() {
         let mut systems = test_systems(&["CH"]).boxed();
         // do not include any neighbors
         let strategy = ThreeBodiesSpeciesSamples::with_self_contribution(0.5);
@@ -437,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_self_contribution_gradients() {
+    fn self_contribution_gradients() {
         let mut systems = test_systems(&["CH"]).boxed();
         let strategy = ThreeBodiesSpeciesSamples::with_self_contribution(2.0);
         let (_, gradients) = strategy.with_gradients(&mut systems).unwrap();
@@ -481,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn three_bodies_self_contribution_partial_gradients() {
+    fn self_contribution_partial_gradients() {
         let mut indexes = IndexesBuilder::new(vec!["structure", "center", "species_center", "species_neighbor_1", "species_neighbor_2"]);
         indexes.add(&[v!(0), v!(1), v!(6), v!(1), v!(1)]);
         indexes.add(&[v!(1), v!(1), v!(1), v!(123456), v!(123456)]);

--- a/rascaline/src/descriptor/mod.rs
+++ b/rascaline/src/descriptor/mod.rs
@@ -2,7 +2,7 @@ mod indexes;
 pub use self::indexes::{Indexes, IndexesBuilder, IndexValue};
 pub use self::indexes::SamplesIndexes;
 pub use self::indexes::{StructureSamples, AtomSamples};
-pub use self::indexes::{StructureSpeciesSamples, AtomSpeciesSamples};
+pub use self::indexes::{StructureSpeciesSamples, TwoBodiesSpeciesSamples};
 pub use self::indexes::{ThreeBodiesSpeciesSamples};
 
 #[allow(clippy::module_inception)]


### PR DESCRIPTION
It is more consistent with the ThreeBodiesSpeciesSamples implementation