### PR TITLE
Store the name used to create the calculator in CalculatorBase

### DIFF
--- a/python/rascaline/calculators.py
+++ b/python/rascaline/calculators.py
@@ -93,6 +93,7 @@ def _options_to_c(use_native_system, samples, features):
 
 class CalculatorBase:
     def __init__(self, name, parameters):
+        self._c_name = name
         self._lib = _get_library()
         parameters = json.dumps(parameters)
         self._as_parameter_ = self._lib.rascal_calculator(
@@ -106,12 +107,17 @@ class CalculatorBase:
 
     @property
     def name(self):
-        """The name used to register this calculator"""
+        """The name of this calculator"""
         return _call_with_growing_buffer(
             lambda buffer, bufflen: self._lib.rascal_calculator_name(
                 self, buffer, bufflen
             )
         )
+
+    @property
+    def c_name(self):
+        """The name used to register & create this calculator"""
+        return self._c_name
 
     @property
     def parameters(self):

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -17,6 +17,8 @@ class TestDummyCalculator(unittest.TestCase):
             " - name: foo - gradients: true",
         )
 
+        self.assertEqual(calculator.c_name, "dummy_calculator")
+
         # very long name, checking that we can pass large string back and forth
         name = "abc" * 2048
         calculator = DummyCalculator(cutoff=3.2, delta=12, name=name, gradients=True)
@@ -149,6 +151,7 @@ class TestSortedDistances(unittest.TestCase):
     def test_name(self):
         calculator = SortedDistances(cutoff=3.5, max_neighbors=12)
         self.assertEqual(calculator.name, "sorted distances vector")
+        self.assertEqual(calculator.c_name, "sorted_distances")
 
     def test_parameters(self):
         calculator = SortedDistances(cutoff=3.5, max_neighbors=12)


### PR DESCRIPTION
It can be used later if we want to change the hyper parameters: one can get `c_name` & `parameters`, change parameters & re-create a new calculator.