### PR TITLE
Add a function to get the number of features a calculator will produce

### DIFF
--- a/docs/src/reference/c/calculators.rst
+++ b/docs/src/reference/c/calculators.rst
@@ -10,6 +10,7 @@ The following functions operate on :c:type:`rascal_calculator_t`:
 - :c:func:`rascal_calculator_compute`: run the actual calculation
 - :c:func:`rascal_calculator_name` get the name of a calculator
 - :c:func:`rascal_calculator_parameters`: get the hyper-parameters of a calculator
+- :c:func:`rascal_calculator_features_count`: get the default number of features
 
 .. doxygenfunction:: rascal_calculator
 
@@ -21,6 +22,7 @@ The following functions operate on :c:type:`rascal_calculator_t`:
 
 .. doxygenfunction:: rascal_calculator_parameters
 
+.. doxygenfunction:: rascal_calculator_features_count
 
 .. doxygenstruct:: rascal_calculation_options_t
     :members:

--- a/python/rascaline/_rascaline.py
+++ b/python/rascaline/_rascaline.py
@@ -182,6 +182,12 @@ def setup_functions(lib):
     ]
     lib.rascal_calculator_parameters.restype = _check_rascal_status_t
 
+    lib.rascal_calculator_features_count.argtypes = [
+        POINTER(rascal_calculator_t),
+        POINTER(c_uintptr_t)
+    ]
+    lib.rascal_calculator_features_count.restype = _check_rascal_status_t
+
     lib.rascal_calculator_compute.argtypes = [
         POINTER(rascal_calculator_t),
         POINTER(rascal_descriptor_t),

--- a/python/rascaline/calculators.py
+++ b/python/rascaline/calculators.py
@@ -122,6 +122,21 @@ class CalculatorBase:
             )
         )
 
+    def features_count(self):
+        """
+        Get the default number of features this calculator will produce.
+
+        This number corresponds to the size of second dimension of the
+        ``values`` and ``gradients`` arrays of the
+        :py:class:`rascaline.Descriptor` returned by
+        :py:func:`rascaline.calculators.CalculatorBase.compute`.
+        """
+        return _call_with_growing_buffer(
+            lambda buffer, bufflen: self._lib.rascal_calculator_parameters(
+                self, buffer, bufflen
+            )
+        )
+
     def compute(
         self,
         systems,

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -562,6 +562,24 @@ rascal_status_t rascal_calculator_parameters(const struct rascal_calculator_t *c
                                              uintptr_t bufflen);
 
 /**
+ * Get the default number of features this `calculator` will produce in the
+ * `count` parameter.
+ *
+ * This number corresponds to the size of second dimension of the `values` and
+ * `gradients` arrays in the `rascal_descriptor_t` after a call to
+ * `rascal_calculator_compute`.
+ *
+ * @param calculator pointer to an existing calculator
+ * @param features pointer to an integer to be filled with the number of features
+ *
+ * @returns The status code of this operation. If the status is not
+ *          `RASCAL_SUCCESS`, you can use `rascal_last_error()` to get the full
+ *          error message.
+ */
+rascal_status_t rascal_calculator_features_count(const struct rascal_calculator_t *calculator,
+                                                 uintptr_t *features);
+
+/**
  * Run a calculation with the given `calculator` on the given `systems`,
  * storing the resulting data in the `descriptor`.
  *

--- a/rascaline-c-api/include/rascaline.hpp
+++ b/rascaline-c-api/include/rascaline.hpp
@@ -805,6 +805,19 @@ public:
         }
     }
 
+    /// Get the default number of features this calculator will produce.
+    ///
+    /// This number corresponds to the size of second dimension of the `values`
+    /// and `gradients` arrays in the `Descriptor` after a call to
+    /// `Calculator::compute`.
+    uintptr_t features_count() const {
+        uintptr_t count = 0;
+        details::check_status(rascal_calculator_features_count(
+            calculator_, &count
+        ));
+        return count;
+    }
+
     /// Run a calculation with this `calculator` on the given `systems`, storing
     /// the resulting data in the `descriptor`. Options for this calculation can
     /// be passed in `options`.

--- a/rascaline-c-api/src/calculator.rs
+++ b/rascaline-c-api/src/calculator.rs
@@ -147,6 +147,31 @@ pub unsafe extern fn rascal_calculator_parameters(
     })
 }
 
+/// Get the default number of features this `calculator` will produce in the
+/// `count` parameter.
+///
+/// This number corresponds to the size of second dimension of the `values` and
+/// `gradients` arrays in the `rascal_descriptor_t` after a call to
+/// `rascal_calculator_compute`.
+///
+/// @param calculator pointer to an existing calculator
+/// @param features pointer to an integer to be filled with the number of features
+///
+/// @returns The status code of this operation. If the status is not
+///          `RASCAL_SUCCESS`, you can use `rascal_last_error()` to get the full
+///          error message.
+#[no_mangle]
+pub unsafe extern fn rascal_calculator_features_count(
+    calculator: *const rascal_calculator_t,
+    features: *mut usize
+) -> rascal_status_t {
+    catch_unwind(|| {
+        check_pointers!(calculator, features);
+        *features = (*calculator).default_features().count();
+        Ok(())
+    })
+}
+
 /// Options that can be set to change how a calculator operates.
 #[repr(C)]
 pub struct rascal_calculation_options_t {

--- a/rascaline-c-api/tests/c-api/calculator.cpp
+++ b/rascaline-c-api/tests/c-api/calculator.cpp
@@ -100,6 +100,40 @@ TEST_CASE("calculator parameters") {
     }
 }
 
+TEST_CASE("calculator features count") {
+    SECTION("dummy_calculator") {
+        std::string HYPERS_JSON = R"({
+            "cutoff": 3.5,
+            "delta": 25,
+            "name": "bar",
+            "gradients": false
+        })";
+        auto* calculator = rascal_calculator("dummy_calculator", HYPERS_JSON.c_str());
+        REQUIRE(calculator != nullptr);
+
+        uintptr_t count = 0;
+        CHECK_SUCCESS(rascal_calculator_features_count(calculator, &count));
+        CHECK(count == 2);
+
+        rascal_calculator_free(calculator);
+    }
+
+    SECTION("sorted distances vector") {
+        std::string HYPERS_JSON = R"({
+            "cutoff": 3.5,
+            "max_neighbors": 25
+        })";
+        auto* calculator = rascal_calculator("sorted_distances", HYPERS_JSON.c_str());
+        REQUIRE(calculator != nullptr);
+
+        uintptr_t count = 0;
+        CHECK_SUCCESS(rascal_calculator_features_count(calculator, &count));
+        CHECK(count == 25);
+
+        rascal_calculator_free(calculator);
+    }
+}
+
 TEST_CASE("calculator creation errors") {
     const char* HYPERS_JSON = R"({
         "cutoff": "532",

--- a/rascaline-c-api/tests/c-api/cxx/calculator.cpp
+++ b/rascaline-c-api/tests/c-api/cxx/calculator.cpp
@@ -67,6 +67,28 @@ TEST_CASE("Calculator parameters") {
     }
 }
 
+TEST_CASE("calculator features count") {
+    SECTION("dummy_calculator") {
+        std::string HYPERS_JSON = R"({
+            "cutoff": 3.5,
+            "delta": 25,
+            "name": "bar",
+            "gradients": false
+        })";
+        auto calculator = rascaline::Calculator("dummy_calculator", HYPERS_JSON);
+        CHECK(calculator.features_count() == 2);
+    }
+
+    SECTION("sorted distances vector") {
+        std::string HYPERS_JSON = R"({
+            "cutoff": 3.5,
+            "max_neighbors": 25
+        })";
+        auto calculator = rascaline::Calculator("sorted_distances", HYPERS_JSON);
+        CHECK(calculator.features_count() == 25);
+    }
+}
+
 TEST_CASE("calculator creation errors") {
     const char* HYPERS_JSON = R"({
         "cutoff": "532",

--- a/rascaline/src/calculator.rs
+++ b/rascaline/src/calculator.rs
@@ -159,6 +159,11 @@ impl Calculator {
         &self.parameters
     }
 
+    /// Get the default set of features for this calculator
+    pub fn default_features(&self) -> Indexes {
+        self.implementation.features()
+    }
+
     /// Compute the descriptor for all the given `systems` and store it in
     /// `descriptor`
     ///

--- a/rascaline/src/descriptor/indexes/samples.rs
+++ b/rascaline/src/descriptor/indexes/samples.rs
@@ -51,7 +51,7 @@ impl SamplesIndexes for StructureSamples {
 /// atoms inside a sphere centered on the central atom.
 ///
 /// This type of indexes does not contain any chemical species information, for
-/// this you should use [`super::AtomSpeciesSamples`].
+/// this you should use [`super::TwoBodiesSpeciesSamples`].
 ///
 /// The base set of indexes contains `structure` and `center` (i.e. central atom
 /// index inside the structure); the gradient indexes also contains the


### PR DESCRIPTION
This is useful for the torch integration, to create linear layers taking the features as output with known size. 

Unfortunately, there is no way to know the final number of features after calling `densify`, so this will not fully solve the issue above.