### PR TITLE
Use the cmake build system to build the lib in python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ Cargo.lock
 .tox/
 build/
 dist/
+_skbuild/
 *.egg-info
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
     "setuptools >=44",
-    "wheel >=0.36"
+    "wheel >=0.36",
+    "scikit-build",
+    "cmake",
+    "ninja",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -19,6 +22,7 @@ passenv =
     CARGO_HOME
 
 deps =
+    scikit-build
     discover
     numpy
     ase
@@ -36,6 +40,7 @@ passenv =
     CARGO_HOME
 
 deps =
+    scikit-build
     discover
     numpy
 
@@ -51,6 +56,7 @@ passenv =
     CARGO_HOME
 
 deps =
+    scikit-build
     numpy
     chemfiles
 

--- a/python/rascaline/clib.py
+++ b/python/rascaline/clib.py
@@ -33,7 +33,7 @@ def _lib_path():
     else:
         raise ImportError("Unknown platform. Please edit this file")
 
-    path = os.path.join(os.path.dirname(__file__), name)
+    path = os.path.join(os.path.dirname(__file__), "lib", name)
     if os.path.isfile(path):
         if windows:
             _check_dll(path)

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -1,6 +1,16 @@
 # Basic CMake integration for rascaline.
 cmake_minimum_required(VERSION 3.10)
 
+if (POLICY CMP0077)
+    # use variables to set OPTIONS
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
+if (SKBUILD)
+    # make sure the library and headers are stored inside the rascaline python module
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/rascaline")
+endif()
+
 file(STRINGS "Cargo.toml" CARGO_TOML_CONTENT)
 string(REGEX REPLACE ".*version = \"([0-9]+\\.[0-9]+\\.[0-9]+)\".*" "\\1" RASCALINE_VERSION ${CARGO_TOML_CONTENT})
 
@@ -11,6 +21,13 @@ project(rascaline
 
 option(RASCAL_DISABLE_CHEMFILES "Disable the usage of chemfiles for reading structures from files" OFF)
 option(BUILD_SHARED_LIBS "Build a shared library instead of a static one" ON)
+
+set(LIB_INSTALL_DIR "lib" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install libraries")
+set(INCLUDE_INSTALL_DIR "include" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install headers")
+
+set(CMAKE_MACOSX_RPATH ON)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
+
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     if("${CMAKE_BUILD_TYPE}" STREQUAL "" AND "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
@@ -82,7 +99,7 @@ file(GLOB_RECURSE ALL_RUST_SOURCES
     ${PROJECT_SOURCE_DIR}/src/**.rs
 )
 
-set(RASCALINE_LIBDIR "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}/")
+set(RASCALINE_LIBDIR "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}/deps")
 if(${BUILD_SHARED_LIBS})
     add_library(rascaline SHARED IMPORTED GLOBAL)
     set(RASCALINE_LOCATION "${RASCALINE_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rascaline${CMAKE_SHARED_LIBRARY_SUFFIX}")
@@ -132,9 +149,6 @@ endif()
 #------------------------------------------------------------------------------#
 # Installation configuration
 #------------------------------------------------------------------------------#
-
-set(LIB_INSTALL_DIR "lib" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install libraries")
-set(INCLUDE_INSTALL_DIR "include" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install headers")
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
 # -*- coding=utf-8 -*-
 import os
 import sys
-import subprocess
 
-from setuptools import setup
-from setuptools.dist import Distribution
+from skbuild import setup
 from wheel.bdist_wheel import bdist_wheel
-from distutils.command.build_ext import build_ext
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
 
 if sys.version_info < (3, 6):
     sys.exit("Sorry, Python < 3.6 is not supported")
 
+# do not include chemfiles inside rascaline, instead users should use
+# chemfiles python bindings directly
+cmake_args = ["-DRASCAL_DISABLE_CHEMFILES=ON"]
 
 RASCALINE_BUILD_TYPE = os.environ.get("RASCALINE_BUILD_TYPE", "release")
 if RASCALINE_BUILD_TYPE not in ["debug", "release"]:
@@ -21,73 +21,27 @@ if RASCALINE_BUILD_TYPE not in ["debug", "release"]:
         "expected 'debug' or 'release'"
     )
 
-
-class BinaryDistribution(Distribution):
-    """
-    This is necessary because otherwise the wheel does not know that
-    it contains a compiled module
-    """
-
-    def has_ext_modules(self):
-        return True
+cmake_args.append(f"-DCMAKE_BUILD_TYPE={RASCALINE_BUILD_TYPE}")
 
 
 class universal_wheel(bdist_wheel):
-    # Workaround until https://github.com/pypa/wheel/issues/185 is resolved
+    # When building the wheel, the `wheel` package assumes that if we have a
+    # binary extension then we are linking to `libpython.so`; and thus the wheel
+    # is only usable with a single python version. This is not the case for
+    # here, and the wheel will be compatible with any Python >=3.6. This is
+    # tracked in https://github.com/pypa/wheel/issues/185, but until then we
+    # manually override the wheel tag.
     def get_tag(self):
         tag = bdist_wheel.get_tag(self)
+        # tag[2:] contains the os/arch tags, we want to keep them
         return ("py3", "none") + tag[2:]
 
 
-class cargo_ext(build_ext):
-    """
-    Build rust code using cargo
-    """
-
-    def run(self):
-        if sys.platform.startswith("darwin"):
-            dylib = "librascaline.dylib"
-        elif sys.platform.startswith("linux"):
-            dylib = "librascaline.so"
-        elif sys.platform.startswith("win"):
-            dylib = "librascaline.dll"
-        else:
-            raise ImportError("Unknown platform. Please edit this file")
-
-        cargo_build = [
-            "cargo",
-            "build",
-            # do not include chemfiles when building the Python package
-            "--no-default-features",
-        ]
-        if RASCALINE_BUILD_TYPE == "release":
-            cargo_build.append("--release")
-
-        process = subprocess.Popen(
-            cargo_build, cwd=os.path.join(ROOT, "rascaline-c-api")
-        )
-        status = process.wait()
-        if status != 0:
-            sys.exit(status)
-
-        dst = os.path.join(self.build_lib, "rascaline", dylib)
-        try:
-            os.makedirs(os.path.dirname(dst))
-        except OSError:
-            pass
-
-        src = os.path.join(ROOT, "target", RASCALINE_BUILD_TYPE, dylib)
-        if os.path.isfile(src):
-            self.copy_file(src, dst)
-        else:
-            raise Exception("Failed to build rust code")
-
-
 setup(
-    distclass=BinaryDistribution,
     ext_modules=[],
     cmdclass={
-        "build_ext": cargo_ext,
         "bdist_wheel": universal_wheel,
     },
+    cmake_source_dir="rascaline-c-api",
+    cmake_args=cmake_args,
 )


### PR DESCRIPTION
This removed duplication of functionalities such as disabling chemfiles
or using `@rpath/librascaline.dylib` as the link id on macOS

This also install headers & cmake configuration inside the python module,
allowing to use it to link another project (such as the pytorch integration)
with rascaline