### PR TITLE
Do not use skbuild to build the Python module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ Cargo.lock
 .tox/
 build/
 dist/
-_skbuild/
 *.egg-info
 __pycache__/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include rascaline *
 recursive-include rascaline-c-api *
 include Cargo.*
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 requires = [
     "setuptools >=44",
     "wheel >=0.36",
-    "scikit-build",
     "cmake",
-    "ninja",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -22,7 +20,6 @@ passenv =
     CARGO_HOME
 
 deps =
-    scikit-build
     discover
     numpy
     ase
@@ -40,7 +37,6 @@ passenv =
     CARGO_HOME
 
 deps =
-    scikit-build
     discover
     numpy
 
@@ -56,7 +52,6 @@ passenv =
     CARGO_HOME
 
 deps =
-    scikit-build
     numpy
     chemfiles
 

--- a/python/rascaline/__init__.py
+++ b/python/rascaline/__init__.py
@@ -11,4 +11,20 @@ from .calculators import SortedDistances
 from .calculators import SphericalExpansion
 from .calculators import SoapPowerSpectrum
 
-__version__ = "0.0.0"
+# Get the __version__ attribute from setuptools metadata (which took it from
+# Cargo.toml) cf https://stackoverflow.com/a/17638236/4692076
+from pkg_resources import get_distribution, DistributionNotFound
+import os
+
+try:
+    dist = get_distribution("rascaline")
+    # Normalize case for Windows systems
+    dist_loc = os.path.normcase(dist.location)
+    here = os.path.normcase(__file__)
+    if not here.startswith(os.path.join(dist_loc, "rascaline")):
+        # not installed, but there is another version that *is*
+        raise DistributionNotFound
+except DistributionNotFound:
+    __version__ = "dev"
+else:
+    __version__ = dist.version

--- a/python/rascaline/clib.py
+++ b/python/rascaline/clib.py
@@ -6,6 +6,11 @@ from ctypes import cdll
 from ._rascaline import setup_functions
 from .log import set_logging_callback, default_logging_callback
 
+_HERE = os.path.realpath(os.path.dirname(__file__))
+
+# path that can be used with cmake to access the rascaline library and headers
+cmake_prefix_path = os.path.join(_HERE, "lib", "cmake")
+
 
 class RascalFinder(object):
     def __init__(self):
@@ -33,7 +38,7 @@ def _lib_path():
     else:
         raise ImportError("Unknown platform. Please edit this file")
 
-    path = os.path.join(os.path.dirname(__file__), "lib", name)
+    path = os.path.join(os.path.join(_HERE, "lib"), name)
     if os.path.isfile(path):
         if windows:
             _check_dll(path)

--- a/python/tests/misc.py
+++ b/python/tests/misc.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import os
+import unittest
+
+import rascaline
+
+
+class TestCMakePrefixPath(unittest.TestCase):
+    def test_cmake_prefix_path_exists(self):
+        self.assertTrue(hasattr(rascaline.clib, "cmake_prefix_path"))
+        self.assertTrue(isinstance(rascaline.clib.cmake_prefix_path, str))
+
+    def test_cmake_files_exists(self):
+        cmake = os.path.join(rascaline.clib.cmake_prefix_path, "rascaline")
+        self.assertTrue(os.path.isfile(os.path.join(cmake, "rascaline-config.cmake")))
+        self.assertTrue(
+            os.path.isfile(os.path.join(cmake, "rascaline-config-version.cmake"))
+        )

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -6,11 +6,6 @@ if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 
-if (SKBUILD)
-    # make sure the library and headers are stored inside the rascaline python module
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/rascaline")
-endif()
-
 file(STRINGS "Cargo.toml" CARGO_TOML_CONTENT)
 foreach(line ${CARGO_TOML_CONTENT})
     string(REGEX REPLACE "version = \"([0-9]+\\.[0-9]+\\.[0-9]+)\".*" "\\1" RASCALINE_VERSION ${line})
@@ -105,7 +100,7 @@ file(GLOB_RECURSE ALL_RUST_SOURCES
     ${PROJECT_SOURCE_DIR}/src/**.rs
 )
 
-set(RASCALINE_LIBDIR "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}/deps")
+set(RASCALINE_LIBDIR "${PROJECT_SOURCE_DIR}/../target/${CARGO_BUILD_TYPE}")
 if(${BUILD_SHARED_LIBS})
     add_library(rascaline SHARED IMPORTED GLOBAL)
     set(RASCALINE_LOCATION "${RASCALINE_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rascaline${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -169,5 +169,5 @@ install(FILES ${RASCALINE_LOCATION} DESTINATION ${LIB_INSTALL_DIR})
 install(FILES
     ${PROJECT_BINARY_DIR}/rascaline-config-version.cmake
     ${PROJECT_BINARY_DIR}/rascaline-config.cmake
-    DESTINATION ${LIB_INSTALL_DIR}/cmake/chemfiles
+    DESTINATION ${LIB_INSTALL_DIR}/cmake/rascaline
 )

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -117,6 +117,16 @@ add_custom_target(cargo-build-rascaline ALL
     COMMENT "Building ${RASCALINE_LIB_NAME} with cargo"
 )
 
+if (RASCAL_BUILD_FOR_PYTHON)
+    if (APPLE)
+        # set the build id of librascaline.dylib to `@rpath/librascaline.dylib`
+        # instead of the full build path (${RASCALINE_LOCATION})
+        add_custom_command(TARGET cargo-build-rascaline POST_BUILD
+            COMMAND install_name_tool -id "@rpath/${RASCALINE_LIB_NAME}" ${RASCALINE_LOCATION}
+        )
+    endif()
+endif()
+
 add_dependencies(rascaline cargo-build-rascaline)
 set(RASCALINE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/rascaline.h"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = rascaline
-version = attr: rascaline.__version__
 long_description = file: README.md
 long_description_content_type = text/markdown
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,19 @@ class cmake_ext(build_ext):
         )
 
 
+# read version from Cargo.toml
+with open("rascaline-c-api/Cargo.toml") as fd:
+    for line in fd:
+        if line.startswith("version"):
+            _, version = line.split(" = ")
+            # remove quotes
+            version = version[1:-2]
+            # take the first version in the file, this should be the rascaline
+            # version
+            break
+
 setup(
+    version=version,
     ext_modules=[
         # only declare the extension, it is built & copied as required by cmake
         # in the build_ext command

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,11 @@ class cmake_ext(build_ext):
         cmake_options = [
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
             f"-DCMAKE_BUILD_TYPE={RASCALINE_BUILD_TYPE}",
+            "-DBUILD_SHARED_LIBS=ON",
             # do not include chemfiles inside rascaline, instead users should
             # use chemfiles python bindings directly
             "-DRASCAL_DISABLE_CHEMFILES=ON",
+            "-DRASCAL_BUILD_FOR_PYTHON=ON",
         ]
 
         subprocess.run(


### PR DESCRIPTION
It brings more pain than is helpful. See the first commit message for more explanation.

Partially reverts #45, we are still using the cmake build system.