### PR TITLE
Allow to request a set of values taken by the variables in densify

### DIFF
--- a/python/rascaline/_rascaline.py
+++ b/python/rascaline/_rascaline.py
@@ -153,6 +153,8 @@ def setup_functions(lib):
     lib.rascal_descriptor_densify.argtypes = [
         POINTER(rascal_descriptor_t),
         POINTER(ctypes.c_char_p),
+        c_uintptr_t,
+        POINTER(ctypes.c_int32),
         c_uintptr_t
     ]
     lib.rascal_descriptor_densify.restype = _check_rascal_status_t

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -16,6 +16,7 @@ default = ["rascaline/chemfiles"]
 
 [dependencies]
 rascaline = {path = "../rascaline", version = "0.1.0", default-features = false}
+ndarray = "0.15"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1"
 

--- a/rascaline-c-api/examples/compute-soap.c
+++ b/rascaline-c-api/examples/compute-soap.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
 
     // Transform the descriptor to dense representation,
     // with one sample for each atom-centered environment
-    status = rascal_descriptor_densify(descriptor, densify_variables, 1);
+    status = rascal_descriptor_densify(descriptor, densify_variables, 1, NULL, 0);
     if (status != RASCAL_SUCCESS) {
         printf("Error: %s\n", rascal_last_error());
         goto cleanup;

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -481,8 +481,15 @@ rascal_status_t rascal_descriptor_indexes_names(const struct rascal_descriptor_t
  * Make the given `descriptor` dense along the given `variables`.
  *
  * The `variable` array should contain the name of the variables as
- * NULL-terminated strings, and `count` must be the number of variables in the
- * array.
+ * NULL-terminated strings, and `variables_count` must be the number of
+ * variables in the array.
+ *
+ * The `requested` parameter defines which set of values taken by the
+ * `variables` should be part of the new features. If it is `NULL`, this is the
+ * set of values taken by the variables in the samples. Otherwise, it must be a
+ * pointer to the first element of a 2D row-major array with one row for each
+ * new feature block, and one column for each variable. `requested_size` must
+ * be the number of rows in this array.
  *
  * This function "moves" the variables from the samples to the features,
  * filling the new features with zeros if the corresponding sample is missing.
@@ -526,13 +533,16 @@ rascal_status_t rascal_descriptor_indexes_names(const struct rascal_descriptor_t
  * |     1     |         | 0 | 0 | 5 | 6 | 7 | 8 |
  * +-----------+---------+---+---+---+---+---+---+
  * ```
+ *
  * Notice how there is only one row/sample for each structure now, and how each
  * value for `species` have created a full block of features. Missing values
  * (e.g. structure 0/species 8) have been filled with 0.
  */
 rascal_status_t rascal_descriptor_densify(struct rascal_descriptor_t *descriptor,
                                           const char *const *variables,
-                                          uintptr_t count);
+                                          uintptr_t variables_count,
+                                          const int32_t *requested,
+                                          uintptr_t requested_size);
 
 /**
  * Create a new calculator with the given `name` and `parameters`.

--- a/rascaline-c-api/tests/c-api/cxx/descriptor.cpp
+++ b/rascaline-c-api/tests/c-api/cxx/descriptor.cpp
@@ -147,10 +147,16 @@ TEST_CASE("Descriptor") {
         descriptor.densify({"center"});
         CHECK(descriptor.values().shape() == std::array<size_t, 2>{1, 8});
 
+        compute_descriptor(descriptor);
+        auto requested = std::vector<int32_t>{1, 3, 7};
+        descriptor.densify({"center"}, rascaline::ArrayView<int32_t>(requested.data(), {3, 1}));
+        CHECK(descriptor.values().shape() == std::array<size_t, 2>{1, 6});
+
+        compute_descriptor(descriptor);
         CHECK_THROWS_WITH(
             descriptor.densify({"not there"}),
-            "internal error: can not densify along 'not there' which is not "
-            "present in the samples: [structure]"
+            "invalid parameter: can not densify along 'not there' which is not "
+            "present in the samples: [structure, center]"
         );
     }
 }

--- a/rascaline-c-api/tests/c-api/descriptor.cpp
+++ b/rascaline-c-api/tests/c-api/descriptor.cpp
@@ -240,7 +240,9 @@ TEST_CASE("rascal_descriptor_t") {
         CHECK(features == 2);
 
         const char* variables[] = { "center" };
-        CHECK_SUCCESS(rascal_descriptor_densify(descriptor, variables, 1));
+        CHECK_SUCCESS(rascal_descriptor_densify(
+            descriptor, variables, 1, NULL, 0
+        ));
 
         CHECK_SUCCESS(rascal_descriptor_values(
             descriptor, &data, &environments, &features
@@ -250,8 +252,21 @@ TEST_CASE("rascal_descriptor_t") {
         CHECK(features == 8);
 
         compute_descriptor(descriptor);
+        int32_t requested[] = {1, 3, 6};
+        CHECK_SUCCESS(rascal_descriptor_densify(
+            descriptor, variables, 1, requested, 3
+        ));
+
+        CHECK_SUCCESS(rascal_descriptor_values(
+            descriptor, &data, &environments, &features
+        ));
+        CHECK(data != nullptr);
+        CHECK(environments == 1);
+        CHECK(features == 3 * 2);
+
+        compute_descriptor(descriptor);
         variables[0] = "not there";
-        CHECK(rascal_descriptor_densify(descriptor, variables, 1) != RASCAL_SUCCESS);
+        CHECK(rascal_descriptor_densify(descriptor, variables, 1, NULL, 0) != RASCAL_SUCCESS);
 
         rascal_descriptor_free(descriptor);
     }

--- a/rascaline/examples/compute-soap.rs
+++ b/rascaline/examples/compute-soap.rs
@@ -33,8 +33,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     calculator.compute(&mut systems, &mut descriptor, Default::default())?;
 
     // Transform the descriptor to dense representation,
-    // with one sample for each atom-centered environment
-    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"]);
+    // with one sample for each atom-centered environment.
+    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"], None)?;
 
     // you can now use descriptor.values as the
     // input of a machine learning algorithm

--- a/rascaline/tests/soap-power-spectrum.rs
+++ b/rascaline/tests/soap-power-spectrum.rs
@@ -17,7 +17,7 @@ fn values() {
     assert_eq!(descriptor.values.shape(), expected.shape());
     assert_relative_eq!(descriptor.values, expected, max_relative=1e-9);
 
-    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"]);
+    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"], None).unwrap();
     let expected: Array2<f64> = data::load_expected_values("soap-power-spectrum-dense-values.npy.gz");
     assert_eq!(descriptor.values.shape(), expected.shape());
     assert_relative_eq!(descriptor.values, expected, max_relative=1e-9);
@@ -38,7 +38,7 @@ fn gradients() {
     assert_eq!(gradients.shape(), expected.shape());
     assert_relative_eq!(*gradients, expected, max_relative=1e-9);
 
-    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"]);
+    descriptor.densify(&["species_neighbor_1", "species_neighbor_2"], None).unwrap();
     let expected: Array2<f64> = data::load_expected_values("soap-power-spectrum-dense-gradients.npy.gz");
 
     let gradients = descriptor.gradients.as_ref().unwrap();


### PR DESCRIPTION
This takes the place of `expansion_by_species` & `global_species` in librascal, allowing the user to specify which values should the densified variables take.