### PR TITLE
Add a `Descriptor::densify_values` function

### DIFF
--- a/python/rascaline/_rascaline.py
+++ b/python/rascaline/_rascaline.py
@@ -63,12 +63,20 @@ class rascal_system_t(ctypes.Structure):
     _fields_ = [
         ("user_data", ctypes.c_void_p),
         ("size", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(c_uintptr_t))),
-        ("species", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(ndpointer(c_uintptr_t, flags='C_CONTIGUOUS')))),
+        ("species", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(ndpointer(ctypes.c_int32, flags='C_CONTIGUOUS')))),
         ("positions", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(ndpointer(ctypes.c_double, flags='C_CONTIGUOUS')))),
         ("cell", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(ctypes.c_double))),
         ("compute_neighbors", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, ctypes.c_double)),
         ("pairs", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, POINTER(ndpointer(rascal_pair_t, flags='C_CONTIGUOUS')), POINTER(c_uintptr_t))),
         ("pairs_containing", CFUNCTYPE(rascal_status_t, ctypes.c_void_p, c_uintptr_t, POINTER(ndpointer(rascal_pair_t, flags='C_CONTIGUOUS')), POINTER(c_uintptr_t))),
+    ]
+
+
+class rascal_densified_position_t(ctypes.Structure):
+    _fields_ = [
+        ("old_sample", c_uintptr_t),
+        ("new_sample", c_uintptr_t),
+        ("feature_block", c_uintptr_t),
     ]
 
 
@@ -159,6 +167,17 @@ def setup_functions(lib):
         c_uintptr_t
     ]
     lib.rascal_descriptor_densify.restype = _check_rascal_status_t
+
+    lib.rascal_descriptor_densify_values.argtypes = [
+        POINTER(rascal_descriptor_t),
+        POINTER(ctypes.c_char_p),
+        c_uintptr_t,
+        POINTER(ctypes.c_int32),
+        c_uintptr_t,
+        POINTER(POINTER(rascal_densified_position_t)),
+        POINTER(c_uintptr_t)
+    ]
+    lib.rascal_descriptor_densify_values.restype = _check_rascal_status_t
 
     lib.rascal_calculator.argtypes = [
         ctypes.c_char_p,

--- a/python/rascaline/systems/base.py
+++ b/python/rascaline/systems/base.py
@@ -71,7 +71,7 @@ class SystemBase:
             """
             self = get_self(user_data)
 
-            species = np.array(self.species(), dtype=c_uintptr_t)
+            species = np.array(self.species(), dtype=np.int32)
             data[0] = species.ctypes.data
             self._keepalive["species"] = species
 

--- a/python/tests/descriptor.py
+++ b/python/tests/descriptor.py
@@ -187,7 +187,7 @@ class TestDummyDescriptor(unittest.TestCase):
         descriptor = compute_descriptor()
         descriptor.densify("center", [1, 3, 8])
         self.assertEqual(descriptor.values.shape, (1, 6))
-        self.assertEqual(descriptor.gradients.shape, (12, 6))
+        self.assertEqual(descriptor.gradients.shape, (6, 6))
 
         descriptor = compute_descriptor()
         with self.assertRaises(RascalError) as cm:
@@ -198,3 +198,22 @@ class TestDummyDescriptor(unittest.TestCase):
             "invalid parameter: can not densify along 'not there' which is not "
             + "present in the samples: [structure, center]",
         )
+
+        descriptor = compute_descriptor()
+        densified_positions = descriptor.densify_values("center")
+        self.assertEqual(descriptor.values.shape, (1, 8))
+        # gradients were not changed
+        self.assertEqual(descriptor.gradients.shape, (18, 2))
+
+        self.assertEqual(densified_positions.shape, (18,))
+        self.assertEqual(densified_positions[0]["old_sample"], 0)
+        self.assertEqual(densified_positions[0]["new_sample"], 0)
+        self.assertEqual(densified_positions[0]["feature_block"], 0)
+
+        self.assertEqual(densified_positions[6]["old_sample"], 6)
+        self.assertEqual(densified_positions[6]["new_sample"], 6)
+        self.assertEqual(densified_positions[6]["feature_block"], 1)
+
+        self.assertEqual(densified_positions[15]["old_sample"], 15)
+        self.assertEqual(densified_positions[15]["new_sample"], 6)
+        self.assertEqual(densified_positions[15]["feature_block"], 3)

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -20,6 +20,7 @@ ndarray = "0.15"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1"
 time-graph = {version = "0.1.3", features = ["table", "json"]}
+libc = "0.2"
 
 [build-dependencies]
 cbindgen = "0.20"

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -244,6 +244,30 @@ typedef struct rascal_system_t {
 } rascal_system_t;
 
 /**
+ * `rascal_densified_position_t` contains all the information to reconstruct
+ * the new position of the values/gradients associated with a single sample in
+ * the initial descriptor
+ */
+typedef struct rascal_densified_position_t {
+  /**
+   * Index of the old sample (respectively gradient sample) in the value
+   * (respectively gradients) array. Some samples might not be necessary in
+   * the new array if the user requested only a subset of the values taken by
+   * the densified variables
+   */
+  uintptr_t old_sample;
+  /**
+   * Index of the new sample (respectively gradient sample) in the value
+   * (respectively gradients) array
+   */
+  uintptr_t new_sample;
+  /**
+   * Index of the feature block in the new array
+   */
+  uintptr_t feature_block;
+} rascal_densified_position_t;
+
+/**
  * Options that can be set to change how a calculator operates.
  */
 typedef struct rascal_calculation_options_t {
@@ -548,6 +572,32 @@ rascal_status_t rascal_descriptor_densify(struct rascal_descriptor_t *descriptor
                                           uintptr_t variables_count,
                                           const int32_t *requested,
                                           uintptr_t requested_size);
+
+/**
+ * Make this descriptor dense along the given `variables`, only modifying the
+ * values array, and not the gradients array.
+ *
+ * This function behaves similarly to `rascal_descriptor_densify`, please refer
+ * to its documentation for more information.
+ *
+ * If this descriptor contains gradients, `gradients_positions` will point to
+ * an array allocated with `malloc` containing the list of samples in the old
+ * gradient array that should be used to reconstruct the dense gradient array;
+ * and the new position of the values associated with each of these samples.
+ * Users of this function are expected to `free` the corresponding memory when
+ * they no longer need it.
+ *
+ * This is an advanced function most users should not need to use, used to
+ * implement backward propagation without having to densify the full gradient
+ * array.
+ */
+rascal_status_t rascal_descriptor_densify_values(struct rascal_descriptor_t *descriptor,
+                                                 const char *const *variables,
+                                                 uintptr_t variables_count,
+                                                 const int32_t *requested,
+                                                 uintptr_t requested_size,
+                                                 struct rascal_densified_position_t **gradients_positions,
+                                                 uintptr_t *gradients_positions_count);
 
 /**
  * Create a new calculator with the given `name` and `parameters`.


### PR DESCRIPTION
This will only densify the values of a descriptor, leaving the gradients untouched. This function is intended as an advanced feature, used to implement backward propagation without having to also densify the gradients array and use a lot of RAM storing zeros.