### PR TITLE
Bump minimal rust version to 1.53

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
             cargo-build-flags: --release
             do-valgrind: true
           - os: ubuntu-18.04
-            rust-version: 1.46
+            rust-version: 1.53
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
           - os: ubuntu-18.04
@@ -73,6 +73,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust-version }}
+          default: true
           target: ${{ matrix.rust-target }}
 
       - name: install tests dependencies

--- a/python/rascaline/clib.py
+++ b/python/rascaline/clib.py
@@ -4,7 +4,7 @@ import sys
 from ctypes import cdll
 
 from ._rascaline import setup_functions
-from .log import set_logging_callback, default_logging_callback
+from .log import _set_logging_callback_impl, default_logging_callback
 
 _HERE = os.path.realpath(os.path.dirname(__file__))
 
@@ -21,7 +21,7 @@ class RascalFinder(object):
             path = _lib_path()
             self._cached_dll = cdll.LoadLibrary(path)
             setup_functions(self._cached_dll)
-            set_logging_callback(default_logging_callback)
+            _set_logging_callback_impl(self._cached_dll, default_logging_callback)
         return self._cached_dll
 
 

--- a/python/rascaline/log.py
+++ b/python/rascaline/log.py
@@ -36,6 +36,21 @@ def set_logging_callback(function):
     function return value is ignored.
     """
 
+    from .clib import _get_library
+
+    library = _get_library()
+    _set_logging_callback_impl(library, function)
+
+
+def _set_logging_callback_impl(library, function):
+    """
+    Implementation of :py:func:`set_logging_callback` getting the instance of
+    :py:class:`ctypes.CDLL` for ``librascaline`` as a parameter.
+
+    This is used to setup the default logging callback when loading the library,
+    without a recursive call to :py:func:`_get_library` in this function.
+    """
+
     def wrapper(log_level, message):
         try:
             function(log_level, message.decode("utf8"))
@@ -47,7 +62,4 @@ def set_logging_callback(function):
     global _CURRENT_CALLBACK
     _CURRENT_CALLBACK = rascal_logging_callback_t(wrapper)
 
-    from .clib import _get_library
-
-    library = _get_library()
     library.rascal_set_logging_callback(_CURRENT_CALLBACK)

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -81,13 +81,15 @@ if(CARGO_STATUS AND NOT CARGO_STATUS EQUAL 0)
     )
 endif()
 
-set(REQUIRED_RUST_VERSION "1.46.0")
+set(REQUIRED_RUST_VERSION "1.53.0")
 string(REGEX REPLACE "cargo ([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" CARGO_VERSION ${CARGO_VERSION})
 if (${CARGO_VERSION} VERSION_LESS ${REQUIRED_RUST_VERSION})
     message(FATAL_ERROR
         "your Rust installation is too old (you have version ${CARGO_VERSION}), \
         at least ${REQUIRED_RUST_VERSION} is required"
     )
+else()
+    message(STATUS "Using cargo version ${CARGO_VERSION} at ${CARGO_EXE}")
 endif()
 
 file(GLOB_RECURSE ALL_RUST_SOURCES

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -28,11 +28,7 @@ harness = false
 
 [dependencies]
 ndarray = {version = "0.15", features = ["approx", "rayon"]}
-
-# this is an old version, but the newer one only builds with rustc 1.51 and later.
-# we can update this when we are ready to move to more recent rustc version
-nalgebra = "0.25"
-
+nalgebra = "0.30"
 lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rascaline/src/lib.rs
+++ b/rascaline/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::redundant_field_names, clippy::redundant_closure_for_method_calls)]
 #![allow(clippy::unreadable_literal, clippy::option_if_let_else, clippy::range_plus_one)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::module_name_repetitions)]
+#![allow(clippy::manual_assert)]
 
 #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_wrap, clippy::cast_lossless, clippy::cast_sign_loss)]

--- a/rascaline/src/types/stack_vec.rs
+++ b/rascaline/src/types/stack_vec.rs
@@ -1,5 +1,5 @@
 /// Types that can be used as the backing store for a `StackVec`
-pub unsafe trait Array: Default {
+pub trait Array: Default {
     /// The type of the array's elements.
     type Item;
     /// Returns the number of items the array can hold.
@@ -11,7 +11,7 @@ pub unsafe trait Array: Default {
 macro_rules! impl_array(
     ($($size:expr),+) => {
         $(
-            unsafe impl<T: Default> Array for [T; $size] {
+            impl<T: Default> Array for [T; $size] {
                 type Item = T;
                 fn capacity() -> usize { $size }
                 fn ptr(&self) -> *const T {


### PR DESCRIPTION
This is the version currently in Ubuntu 18.04, and a good minimal version to use (nalgebra wants 1.51). This PR also make sure the CI tests actually run with this version, previously the version was installed but stable was used for the tests.