### PR TITLE
Allow to provide an empty set of selected sample/features

### DIFF
--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -118,6 +118,18 @@ class TestDummyCalculator(unittest.TestCase):
         self.assertTrue(np.all(values[1] == (5, 5)))
         self.assertTrue(np.all(values[2] == (3, 3)))
 
+        # empty selected samples
+        samples = Indexes(
+            array=np.array([], dtype=np.int32).reshape(0, 2),
+            names=["structure", "center"],
+        )
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_samples=samples
+        )
+
+        values = descriptor.values
+        self.assertEqual(values.shape, (0, 2))
+
     def test_compute_partial_samples_errors(self):
         system = TestSystem()
         calculator = DummyCalculator(cutoff=3.2, delta=2, name="", gradients=True)
@@ -207,6 +219,18 @@ class TestDummyCalculator(unittest.TestCase):
 
         values = descriptor.values
         self.assertEqual(values.shape, (4, 1))
+
+        # empty selected features
+        features = Indexes(
+            array=np.array([], dtype=np.int32).reshape(0, 2),
+            names=["index_delta", "x_y_z"],
+        )
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_features=features
+        )
+
+        values = descriptor.values
+        self.assertEqual(values.shape, (4, 0))
 
     def test_compute_partial_features_errors(self):
         system = TestSystem()

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -303,14 +303,14 @@ typedef struct rascal_calculation_options_t {
   bool use_native_system;
   /**
    * List of samples on which to run the calculation. You can set
-   * `selected_samples.values` to `NULL` to run the calculation on all
-   * samples. If necessary, gradients samples will be derived from the
-   * values given in selected_samples.
+   * `selected_samples.names` to `NULL` to run the calculation on all
+   * samples. If necessary, gradients samples will be derived from the values
+   * given in selected_samples.
    */
   struct rascal_indexes_t selected_samples;
   /**
    * List of features on which to run the calculation. You can set
-   * `selected_features.values` to `NULL` to run the calculation on all
+   * `selected_features.names` to `NULL` to run the calculation on all
    * features.
    */
   struct rascal_indexes_t selected_features;

--- a/rascaline-c-api/src/calculator.rs
+++ b/rascaline-c-api/src/calculator.rs
@@ -180,18 +180,18 @@ pub struct rascal_calculation_options_t {
     /// faster than having to cross the FFI boundary too often.
     use_native_system: bool,
     /// List of samples on which to run the calculation. You can set
-    /// `selected_samples.values` to `NULL` to run the calculation on all
-    /// samples. If necessary, gradients samples will be derived from the
-    /// values given in selected_samples.
+    /// `selected_samples.names` to `NULL` to run the calculation on all
+    /// samples. If necessary, gradients samples will be derived from the values
+    /// given in selected_samples.
     selected_samples: rascal_indexes_t,
     /// List of features on which to run the calculation. You can set
-    /// `selected_features.values` to `NULL` to run the calculation on all
+    /// `selected_features.names` to `NULL` to run the calculation on all
     /// features.
     selected_features: rascal_indexes_t,
 }
 
 fn selected_indexes(selected: &rascal_indexes_t) -> Result<SelectedIndexes, Error> {
-    if selected.values.is_null() {
+    if selected.names.is_null() {
         return Ok(SelectedIndexes::All);
     }
     let names = unsafe {

--- a/rascaline-c-api/tests/c-api/calculator.cpp
+++ b/rascaline-c-api/tests/c-api/calculator.cpp
@@ -319,6 +319,48 @@ TEST_CASE("Compute descriptor") {
         }
     }
 
+    SECTION("Partial compute -- empty") {
+        auto system = simple_system();
+
+        auto samples_names = std::vector<const char*> {
+            "structure", "center"
+        };
+        rascal_calculation_options_t options_no_samples = {0};
+        options_no_samples.selected_samples.names = samples_names.data();
+        options_no_samples.selected_samples.size = 2;
+        options_no_samples.selected_samples.values = nullptr;
+        options_no_samples.selected_samples.count = 0;
+
+        CHECK_SUCCESS(rascal_calculator_compute(
+            calculator, descriptor, &system, 1, options_no_samples
+        ));
+
+        double* data = nullptr;
+        uintptr_t shape[2] = {0};
+        CHECK_SUCCESS(rascal_descriptor_values(descriptor, &data, &shape[0], &shape[1]));
+
+        CHECK(shape[0] == 0);
+        CHECK(shape[1] == 2);
+
+        auto features_names = std::vector<const char*> {
+            "index_delta", "x_y_z"
+        };
+        rascal_calculation_options_t options_no_features = {0};
+        options_no_features.selected_features.names = features_names.data();
+        options_no_features.selected_features.size = 2;
+        options_no_features.selected_features.values = nullptr;
+        options_no_features.selected_features.count = 0;
+
+        CHECK_SUCCESS(rascal_calculator_compute(
+            calculator, descriptor, &system, 1, options_no_features
+        ));
+
+        CHECK_SUCCESS(rascal_descriptor_values(descriptor, &data, &shape[0], &shape[1]));
+
+        CHECK(shape[0] == 4);
+        CHECK(shape[1] == 0);
+    }
+
     SECTION("Partial compute -- errors") {
         auto system = simple_system();
 

--- a/rascaline/src/calculators/tests_utils.rs
+++ b/rascaline/src/calculators/tests_utils.rs
@@ -6,7 +6,7 @@ use approx::{assert_relative_eq, assert_ulps_eq};
 
 use crate::{CalculationOptions, Calculator, SelectedIndexes};
 use crate::systems::{System, SimpleSystem};
-use crate::descriptor::{Descriptor, Indexes, IndexValue};
+use crate::descriptor::{Descriptor, Indexes, IndexValue, IndexesBuilder};
 
 /// Check that computing a partial subset of features/samples works as intended
 /// for the given `calculator` and `systems`.
@@ -117,6 +117,30 @@ pub fn compute_partial(
             }
         }
     }
+
+    // check that the calculator works when selecting an empty set of
+    // samples/features
+    let empty_samples = IndexesBuilder::new(samples.names()).finish();
+    let options = CalculationOptions {
+        selected_samples: SelectedIndexes::Subset(empty_samples),
+        selected_features: SelectedIndexes::All,
+        ..Default::default()
+    };
+    calculator.compute(systems, &mut partial, options).unwrap();
+
+    assert_eq!(partial.values.shape()[0], 0);
+    assert_eq!(partial.values.shape()[1], full.values.shape()[1]);
+
+    let empty_features = IndexesBuilder::new(features.names()).finish();
+    let options = CalculationOptions {
+        selected_samples: SelectedIndexes::All,
+        selected_features: SelectedIndexes::Subset(empty_features),
+        ..Default::default()
+    };
+    calculator.compute(systems, &mut partial, options).unwrap();
+
+    assert_eq!(partial.values.shape()[0], full.values.shape()[0]);
+    assert_eq!(partial.values.shape()[1], 0);
 }
 
 /// Check that analytical gradients agree with a finite difference calculation


### PR DESCRIPTION
The main use case is when we have a MD domain with no atoms inside, only "ghosts" atoms from neighboring domains