### PR TITLE
Fixed little typo in comment for GTO width

### DIFF
--- a/rascaline/src/calculators/soap/radial_integral/gto.rs
+++ b/rascaline/src/calculators/soap/radial_integral/gto.rs
@@ -95,7 +95,7 @@ pub struct GtoRadialIntegral {
     hypergeometric: HyperGeometricSphericalExpansion,
     /// 1/2σ^2, with σ the atomic density gaussian width
     atomic_gaussian_constant: f64,
-    /// 1/2σ_n^2, with σ_n the GTO gaussian width, i.e. `cutoff * max(√n, 1) / (n_max + 1) `
+    /// 1/2σ_n^2, with σ_n the GTO gaussian width, i.e. `cutoff * max(√n, 1) / n_max`
     gto_gaussian_constants: Vec<f64>,
     /// `n_max * n_max` matrix to orthonormalize the GTO basis
     gto_orthonormalization: Array2<f64>,


### PR DESCRIPTION
Change the comment according to the expression below eq. 10 of [Musil et. al](https://aip.scitation.org/doi/10.1063/5.0044689). The actual calculation in the code is correct. 