### PR TITLE
Manage the equistore/serialization feature

### DIFF
--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -61,6 +61,10 @@ if (${RASCAL_DISABLE_CHEMFILES})
     set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--no-default-features")
 endif()
 
+if (${RASCAL_BUILD_FOR_PYTHON})
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--features=serialization")
+endif()
+
 # Handle cross compilation with RUST_BUILD_TARGET
 if (NOT "${RUST_BUILD_TARGET}" STREQUAL "")
     set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--target=${RUST_BUILD_TARGET}")

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -12,7 +12,9 @@ crate-type = ["cdylib", "staticlib"]
 bench = false
 
 [features]
-default = ["rascaline/chemfiles"]
+default = ["chemfiles"]
+chemfiles = ["rascaline/chemfiles"]
+serialization = ["equistore/serialization"]
 
 [dependencies]
 rascaline = {path = "../rascaline", version = "0.1.0", default-features = false}


### PR DESCRIPTION
It is now exposed in Cargo and CMake; and enabled when building the Python bindings