### PR TITLE
Structure factors

### DIFF
--- a/rascaline/src/calculators/lode/spherical_expansion.rs
+++ b/rascaline/src/calculators/lode/spherical_expansion.rs
@@ -65,13 +65,18 @@ impl LodeSphericalExpansion {
     }
 
     /// Compute the trigonometric functions for LODE coefficients
-    fn compute_structure_factors(&mut self, positions: &[Vector3D], k_vectors: &[KVector]) -> (Array3::<f64>, Array3::<f64>) {
+struct StructureFactors {
+    real: Array3<f64>,
+    imag: Array3<f64>,
+}
+
+    fn compute_structure_factors(&mut self, positions: &[Vector3D], k_vectors: &[KVector]) -> StructureFactors {
 
         let num_atoms: usize = positions.len();
         let num_kvecs: usize = k_vectors.len();
 
-        let mut cosines= Array2::from_elem((num_kvecs, num_atoms), 0.0);
-        let mut sines= Array2::from_elem((num_kvecs, num_atoms), 0.0);
+        let mut cosines = Array2::from_elem((num_kvecs, num_atoms), 0.0);
+        let mut sines = Array2::from_elem((num_kvecs, num_atoms), 0.0);
     
         // cosines[i, j] = cos(k_i * r_j), same for sines
         for i_k in 0..num_kvecs {

--- a/rascaline/src/calculators/lode/spherical_expansion.rs
+++ b/rascaline/src/calculators/lode/spherical_expansion.rs
@@ -253,8 +253,38 @@ impl CalculatorBase for LodeSphericalExpansion {
             }
             let k_vectors = compute_k_vectors(&cell, 1.0);
 
-            let struc_fac = compute_structure_factors(system.positions()?, &k_vectors);
+            let strucfac = compute_structure_factors(system.positions()?, &k_vectors);
         }
         Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::arr3;
+
+    #[test]
+    fn test_compute_structure_factors() {
+        let mut k_vectors = Vec::new();
+
+        k_vectors.push(KVector{vector: Vector3D::new(1.0, 0.0,0.0), norm: 1.0});
+        k_vectors.push(KVector{vector: Vector3D::new(0.0, 1.0, 0.0), norm: 1.0});
+        
+        let positions = [Vector3D::new(1.0, 1.0, 1.0),
+                                        Vector3D::new(2.0, 2.0, 2.0)];
+
+        let strucfac = compute_structure_factors(&positions, &k_vectors);
+
+        let ref_real= arr3(
+            &[[[2., 2.], [1.0806046117362793, 1.0806046117362793]],
+                  [[1.0806046117362793, 1.0806046117362793],[2. , 2. ]]]);
+        let ref_imag = arr3(
+            &[[[ 0. ,  0. ], [-1.682941969615793, -1.682941969615793]],
+                  [[1.682941969615793, 1.682941969615793],[ 0. ,  0. ]]]);
+
+        assert_eq!(strucfac.imag, ref_imag);
+        assert_eq!(strucfac.real, ref_real);
     }
 }

--- a/rascaline/src/math/mod.rs
+++ b/rascaline/src/math/mod.rs
@@ -15,8 +15,8 @@ pub use self::spherical_harmonics::{SphericalHarmonics, SphericalHarmonicsArray}
 pub use self::spherical_harmonics::CachedAllocationsSphericalHarmonics;
 
 mod k_vectors;
-pub(crate) use self::k_vectors::KVector;
 pub(crate) use self::k_vectors::compute_k_vectors;
+pub(crate) use self::k_vectors::KVector;
 
 mod cutoff;
 pub(crate) use self::cutoff::{CutoffFunction, RadialScaling};


### PR DESCRIPTION
Added implementation for computing LODE structure factors. Basically adapted from pyLODE

```python
args = kvectors @ positions.T
cosines = np.cos(args)
sines = np.sin(args)

strucfac_real = np.zeros((num_kvecs, num_atoms, num_atoms))
strucfac_imag = np.zeros((num_kvecs, num_atoms, num_atoms))

for i in range(num_atoms):
    for j in range(num_atoms):
        strucfac_real[:, i, j] = cosines[:,i] * cosines[:,j] + sines[:,i] * sines[:,j]
        strucfac_imag[:, i, j] = sines[:,i] * cosines[:,j] - cosines[:,i] * sines[:,j]
```

 I will add some tests soon, but comments from @Luthaf on the code structure are appreciated.