### PR TITLE
Implement projection of k-vectors to nlm

### DIFF
--- a/rascaline/src/calculators/lode/gto_radial_integral.rs
+++ b/rascaline/src/calculators/lode/gto_radial_integral.rs
@@ -1,0 +1,183 @@
+use std::f64;
+
+use ndarray::{Array2, ArrayViewMut2};
+
+use crate::math::{gamma, DoubleRegularized1F1};
+use crate::Error;
+
+use crate::calculators::radial_integral::RadialIntegral;
+use crate::calculators::radial_integral::GtoRadialBasis;
+
+pub use super::super::soap::GtoParameters;
+
+/// Implementation of the LODE radial integral for GTO radial basis and Gaussian
+/// atomic density.
+#[derive(Debug, Clone)]
+pub struct LodeGtoRadialIntegral {
+    parameters: GtoParameters,
+    /// σ_n GTO gaussian width, i.e. `cutoff * max(√n, 1) / n_max`
+    gto_gaussian_widths: Vec<f64>,
+    /// `n_max * n_max` matrix to orthonormalize the GTO
+    gto_orthonormalization: Array2<f64>,
+    /// Implementation of `Gamma(a) / Gamma(b) 1F1(a, b, z)`
+    double_regularized_1f1: DoubleRegularized1F1,
+}
+
+impl LodeGtoRadialIntegral {
+    pub fn new(parameters: GtoParameters) -> Result<LodeGtoRadialIntegral, Error> {
+        parameters.validate()?;
+
+        let gto_gaussian_widths = GtoRadialBasis::gaussian_widths(parameters.max_radial, parameters.cutoff);
+
+        let gto_orthonormalization = GtoRadialBasis::orthonormalization_matrix(
+            parameters.max_radial, parameters.cutoff
+        );
+
+        return Ok(LodeGtoRadialIntegral {
+            parameters: parameters,
+            double_regularized_1f1: DoubleRegularized1F1 {
+                max_angular: parameters.max_angular,
+            },
+            gto_gaussian_widths: gto_gaussian_widths,
+            gto_orthonormalization: gto_orthonormalization,
+        })
+    }
+}
+
+impl RadialIntegral for LodeGtoRadialIntegral {
+    #[time_graph::instrument(name = "LodeGtoRadialIntegral::compute")]
+    fn compute(
+        &self,
+        k_norm: f64,
+        mut values: ArrayViewMut2<f64>,
+        mut gradients: Option<ArrayViewMut2<f64>>
+    ) {
+        let expected_shape = [self.parameters.max_angular + 1, self.parameters.max_radial];
+        assert_eq!(
+            values.shape(), expected_shape,
+            "wrong size for values array, expected [{}, {}] but got [{}, {}]",
+            expected_shape[0], expected_shape[1], values.shape()[0], values.shape()[1]
+        );
+
+        if let Some(ref gradients) = gradients {
+            assert_eq!(
+                gradients.shape(), expected_shape,
+                "wrong size for gradients array, expected [{}, {}] but got [{}, {}]",
+                expected_shape[0], expected_shape[1], gradients.shape()[0], gradients.shape()[1]
+            );
+        }
+
+        let global_factor = std::f64::consts::PI.sqrt() / std::f64::consts::SQRT_2;
+
+        for n in 0..self.parameters.max_radial {
+            let sigma_n = self.gto_gaussian_widths[n];
+            let k_sigma_n_sqrt2 = k_norm * sigma_n / std::f64::consts::SQRT_2;
+            // `global_factor * sqrt(2)^{n} * sigma_n^{n + 3} * (k * sigma_n / sqrt(2))^l`
+            let mut factor = global_factor * sigma_n.powi(n as i32 + 3) * std::f64::consts::SQRT_2.powi(n as i32);
+
+            let k_norm_sigma_n_2 = - k_norm * sigma_n * sigma_n;
+            let z = 0.5 * k_norm * k_norm_sigma_n_2;
+            self.double_regularized_1f1.compute(
+                z, n,
+                values.index_axis_mut(ndarray::Axis(1), n),
+                gradients.as_mut().map(|g| g.index_axis_mut(ndarray::Axis(1), n))
+            );
+
+            for l in 0..(self.parameters.max_angular + 1) {
+                values[[l, n]] *= factor;
+                if let Some(ref mut gradients) = gradients {
+                    gradients[[l, n]] *= k_norm_sigma_n_2 * factor;
+                    gradients[[l, n]] += l as f64 / k_norm * values[[l, n]];
+                }
+
+                factor *= k_sigma_n_sqrt2;
+            }
+        }
+
+        // for k_norm = 0, the formula used in the calculations above yield NaN,
+        // which in turns breaks the SplinedGto radial integral. From the
+        // analytical formula, the gradient is 0 everywhere expect for l=1
+        if k_norm == 0.0 {
+            if let Some(ref mut gradients) = gradients {
+                gradients.fill(0.0);
+
+                if self.parameters.max_angular >= 1 {
+                    let l = 1;
+                    for n in 0..self.parameters.max_radial {
+                        let sigma_n = self.gto_gaussian_widths[n];
+                        let a = 0.5 * (n + l) as f64 + 1.5;
+                        let b = 2.5;
+                        let factor = global_factor * sigma_n.powi((n + l) as i32 + 3) * std::f64::consts::SQRT_2.powi(n as i32 - l as i32);
+
+                        gradients[[l, n]] = gamma(a) / gamma(b) * factor;
+                    }
+                }
+            }
+        }
+
+        values.assign(&values.dot(&self.gto_orthonormalization));
+        if let Some(ref mut gradients) = gradients {
+            gradients.assign(&gradients.dot(&self.gto_orthonormalization));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calculators::radial_integral::RadialIntegral;
+
+    use ndarray::Array2;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn gradients_near_zero() {
+        let max_radial = 8;
+        let max_angular = 8;
+        let gto = LodeGtoRadialIntegral::new(GtoParameters {
+            max_radial: max_radial,
+            max_angular: max_angular,
+            cutoff: 5.0,
+            atomic_gaussian_width: 0.5,
+        }).unwrap();
+
+        let shape = (max_angular + 1, max_radial);
+        let mut values = Array2::from_elem(shape, 0.0);
+        let mut gradients = Array2::from_elem(shape, 0.0);
+        let mut gradients_plus = Array2::from_elem(shape, 0.0);
+        gto.compute(0.0, values.view_mut(), Some(gradients.view_mut()));
+        gto.compute(1e-12, values.view_mut(), Some(gradients_plus.view_mut()));
+
+        assert_relative_eq!(
+            gradients, gradients_plus, epsilon=1e-9, max_relative=1e-6,
+        );
+    }
+
+    #[test]
+    fn finite_differences() {
+        let max_radial = 8;
+        let max_angular = 8;
+        let gto = LodeGtoRadialIntegral::new(GtoParameters {
+            max_radial: max_radial,
+            max_angular: max_angular,
+            cutoff: 5.0,
+            atomic_gaussian_width: 0.5,
+        }).unwrap();
+
+        let rij = 3.4;
+        let delta = 1e-6;
+
+        let shape = (max_angular + 1, max_radial);
+        let mut values = Array2::from_elem(shape, 0.0);
+        let mut values_delta = Array2::from_elem(shape, 0.0);
+        let mut gradients = Array2::from_elem(shape, 0.0);
+        gto.compute(rij, values.view_mut(), Some(gradients.view_mut()));
+        gto.compute(rij + delta, values_delta.view_mut(), None);
+
+        let finite_differences = (&values_delta - &values) / delta;
+
+        assert_relative_eq!(
+            finite_differences, gradients, max_relative=1e-4
+        );
+    }
+}

--- a/rascaline/src/calculators/lode/mod.rs
+++ b/rascaline/src/calculators/lode/mod.rs
@@ -1,2 +1,8 @@
+mod gto_radial_integral;
+pub use self::gto_radial_integral::{LodeGtoRadialIntegral, GtoParameters};
+
+mod radial_basis;
+pub use self::radial_basis::LodeRadialBasis;
+
 mod spherical_expansion;
 pub use self::spherical_expansion::{LodeSphericalExpansion, LodeSphericalExpansionParameters};

--- a/rascaline/src/calculators/lode/radial_basis.rs
+++ b/rascaline/src/calculators/lode/radial_basis.rs
@@ -1,0 +1,78 @@
+use crate::calculators::radial_integral::RadialIntegral;
+use crate::calculators::radial_integral::{SplinedRadialIntegral, SplinedRIParameters};
+
+use super::{LodeGtoRadialIntegral, GtoParameters};
+use super::LodeSphericalExpansionParameters;
+
+use crate::Error;
+
+#[derive(Debug, Clone, Copy)]
+#[derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+/// Radial basis that can be used in the LODE spherical expansion
+pub enum LodeRadialBasis {
+    /// Use a radial basis similar to Gaussian-Type Orbitals.
+    ///
+    /// The basis is defined as `R_n(r) ∝ r^n e^{- r^2 / (2 σ_n^2)}`, where `σ_n
+    /// = cutoff * \sqrt{n} / n_max`.
+    ///
+    /// If `splined_radial_integral` is true, we compute the radial integral
+    /// using splines. This is much faster than the base GTO implementation. In
+    /// this case, the number of control points in the spline is automatically
+    /// determined to ensure the average absolute error is close to the
+    /// `spline_accuracy`
+    Gto {
+        #[serde(default = "serde_default_splined_radial_integral")]
+        splined_radial_integral: bool,
+        #[serde(default = "serde_default_spline_accuracy")]
+        spline_accuracy: f64,
+    },
+}
+
+fn serde_default_splined_radial_integral() -> bool { true }
+fn serde_default_spline_accuracy() -> f64 { 1e-8 }
+
+impl LodeRadialBasis {
+    /// Use GTO as the radial basis, and do not spline the radial integral
+    pub fn gto() -> LodeRadialBasis {
+        return LodeRadialBasis::Gto {
+            splined_radial_integral: false, spline_accuracy: 0.0
+        };
+    }
+
+    /// Use GTO as the radial basis, and spline the radial integral
+    pub fn splined_gto(accuracy: f64) -> LodeRadialBasis {
+        return LodeRadialBasis::Gto {
+            splined_radial_integral: true, spline_accuracy: accuracy
+        };
+    }
+
+    /// Construct the right LODE radial integral for the current radial basis &
+    /// set of spherical expansion parameters.
+    pub fn get_radial_integral(&self, parameters: &LodeSphericalExpansionParameters) -> Result<Box<dyn RadialIntegral>, Error> {
+        match self {
+            LodeRadialBasis::Gto { splined_radial_integral, spline_accuracy } => {
+                let parameters = GtoParameters {
+                    max_radial: parameters.max_radial,
+                    max_angular: parameters.max_angular,
+                    atomic_gaussian_width: parameters.atomic_gaussian_width,
+                    cutoff: parameters.cutoff,
+                };
+                let gto = LodeGtoRadialIntegral::new(parameters)?;
+
+                if !splined_radial_integral {
+                    return Ok(Box::new(gto));
+                }
+
+                let parameters = SplinedRIParameters {
+                    max_radial: parameters.max_radial,
+                    max_angular: parameters.max_angular,
+                    cutoff: parameters.cutoff,
+                };
+
+                return Ok(Box::new(SplinedRadialIntegral::with_accuracy(
+                    parameters, *spline_accuracy, gto
+                )?));
+            }
+        };
+    }
+}

--- a/rascaline/src/calculators/lode/spherical_expansion.rs
+++ b/rascaline/src/calculators/lode/spherical_expansion.rs
@@ -1,22 +1,24 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use ndarray::{Array2, Array3};
-use crate::Vector3D;
+use ndarray::{Array2, Array3, s};
 
 use equistore::{LabelsBuilder, Labels, LabelValue};
 use equistore::TensorMap;
 
-use crate::{Error, System};
+use crate::{Error, System, Vector3D};
 use crate::labels::{SamplesBuilder, SpeciesFilter, LongRangePerAtom};
 use crate::labels::{KeysBuilder, CenterSingleNeighborsSpeciesKeys};
 
-use crate::math::{KVector, compute_k_vectors};
 use crate::systems::UnitCell;
 
-use super::super::CalculatorBase;
+use crate::calculators::CalculatorBase;
+use crate::calculators::radial_integral::RadialIntegral;
+
+use super::LodeRadialBasis;
 
 use crate::math::CachedAllocationsSphericalHarmonics;
+use crate::math::{KVector, compute_k_vectors};
 
 
 /// TODO
@@ -32,9 +34,45 @@ pub struct LodeSphericalExpansionParameters {
     /// Width of the atom-centered gaussian used to create the atomic density
     pub atomic_gaussian_width: f64,
     /// Radial basis to use for the radial integral
-    // pub radial_basis: RadialBasis,
+    pub radial_basis: LodeRadialBasis,
     /// TODO
     pub potential_exponent: usize,
+}
+
+struct CachedAllocationsRadialIntegral {
+    /// Implementation of the radial integral
+    code: Box<dyn RadialIntegral>,
+    /// Cache for the radial integral values
+    values: Array2<f64>,
+    /// Cache for the radial integral gradient
+    gradients: Array2<f64>,
+}
+
+impl CachedAllocationsRadialIntegral {
+    fn new(parameters: &LodeSphericalExpansionParameters) -> Result<Self, Error> {
+        let code = parameters.radial_basis.get_radial_integral(parameters)?;
+        let shape = (parameters.max_angular + 1, parameters.max_radial);
+        let values = Array2::from_elem(shape, 0.0);
+        let gradients = Array2::from_elem(shape, 0.0);
+
+        return Ok(CachedAllocationsRadialIntegral { code, values, gradients });
+    }
+
+    fn compute(&mut self, k_norm: f64, gradients: bool) {
+        if gradients {
+            self.code.compute(
+                k_norm,
+                self.values.view_mut(),
+                Some(self.gradients.view_mut()),
+            );
+        } else {
+            self.code.compute(
+                k_norm,
+                self.values.view_mut(),
+                None,
+            );
+        }
+    }
 }
 
 
@@ -44,6 +82,12 @@ pub struct LodeSphericalExpansion {
     parameters: LodeSphericalExpansionParameters,
     /// implementation + cached allocation to compute spherical harmonics
     spherical_harmonics: CachedAllocationsSphericalHarmonics,
+    /// implementation + cached allocation to compute the radial integral
+    radial_integral: CachedAllocationsRadialIntegral,
+    /// Cached allocations for the k_vector => nlm projection coefficients.
+    /// The vector contains different l values, and the Array is indexed by
+    /// `m, n, k`.
+    k_vector_to_m_n: Vec<Array3<f64>>,
 }
 
 /// Compute the trigonometric functions for LODE coefficients
@@ -55,7 +99,6 @@ struct StructureFactors {
 }
 
 fn compute_structure_factors(positions: &[Vector3D], k_vectors: &[KVector]) -> StructureFactors {
-
     let num_atoms: usize = positions.len();
     let num_kvecs: usize = k_vectors.len();
 
@@ -63,36 +106,34 @@ fn compute_structure_factors(positions: &[Vector3D], k_vectors: &[KVector]) -> S
     let mut sines = Array2::from_elem((num_kvecs, num_atoms), 0.0);
 
     // cosines[i, j] = cos(k_i * r_j), same for sines
-    for i_k in 0..num_kvecs {
-        for i_p in 0..num_atoms {
+    for (ik, k_vector) in k_vectors.iter().enumerate() {
+        for (atom_i, position) in positions.iter().enumerate() {
             // dot product between kvectors and positions
-            let s = k_vectors[i_k].vector[0] * positions[i_p][0] +
-                            k_vectors[i_k].vector[1] * positions[i_p][1] +
-                            k_vectors[i_k].vector[2] * positions[i_p][2];
+            let s = k_vector.norm * k_vector.direction * position;
 
-            cosines[[i_k, i_p]] = f64::cos(s);
-            sines[[i_k, i_p]] = f64::sin(s);
+            cosines[[ik, atom_i]] = f64::cos(s);
+            sines[[ik, atom_i]] = f64::sin(s);
         }
     }
 
-    let mut strucfac = StructureFactors {
+    let mut structure_factors = StructureFactors {
         real: Array3::from_elem((num_atoms, num_atoms, num_kvecs), 0.0),
         imag: Array3::from_elem((num_atoms, num_atoms, num_kvecs), 0.0),
     };
-    
+
     for i in 0..num_atoms {
         for j in 0..num_atoms {
             for k in 0..num_kvecs {
-                strucfac.real[[i, j, k]] = cosines[[k, i]] * cosines[[k, j]] + sines[[k, i]] * sines[[k, j]];
-                strucfac.imag[[i, j, k]] = sines[[k, i]] * cosines[[k, j]] - cosines[[k, i]] * sines[[k, j]];
+                structure_factors.real[[i, j, k]] = cosines[[k, i]] * cosines[[k, j]] + sines[[k, i]] * sines[[k, j]];
+                structure_factors.imag[[i, j, k]] = sines[[k, i]] * cosines[[k, j]] - cosines[[k, i]] * sines[[k, j]];
             }
         }
     }
 
-    strucfac.real *= 2.0;
-    strucfac.imag *= 2.0;
+    structure_factors.real *= 2.0;
+    structure_factors.imag *= 2.0;
 
-    return strucfac
+    return structure_factors
 }
 
 impl std::fmt::Debug for LodeSphericalExpansion {
@@ -103,14 +144,55 @@ impl std::fmt::Debug for LodeSphericalExpansion {
 
 impl LodeSphericalExpansion {
     pub fn new(parameters: LodeSphericalExpansionParameters) -> Result<LodeSphericalExpansion, Error> {
+        let radial_integral = CachedAllocationsRadialIntegral::new(&parameters)?;
+
         let spherical_harmonics = CachedAllocationsSphericalHarmonics::new(
             parameters.max_angular,
         );
 
+        let mut k_vector_to_m_n = Vec::new();
+        for _ in 0..=parameters.max_angular {
+            k_vector_to_m_n.push(Array3::from_elem((0, 0, 0), 0.0));
+        }
+
         return Ok(LodeSphericalExpansion {
             parameters,
             spherical_harmonics,
+            radial_integral,
+            k_vector_to_m_n,
         });
+    }
+
+    fn project_k_to_nlm(&mut self, k_vectors: &[KVector], do_gradients: bool) {
+        for spherical_harmonics_l in 0..=self.parameters.max_angular {
+            let shape = (2 * spherical_harmonics_l + 1, self.parameters.max_radial, k_vectors.len());
+
+            // resize the arrays while keeping existing allocations
+            let array = std::mem::take(&mut self.k_vector_to_m_n[spherical_harmonics_l]);
+
+            let mut data = array.into_raw_vec();
+            data.resize(shape.0 * shape.1 * shape.2, 0.0);
+            let array = Array3::from_shape_vec(shape, data).expect("wrong shape");
+
+            self.k_vector_to_m_n[spherical_harmonics_l] = array;
+        }
+
+
+        for (ik, k_vector) in k_vectors.iter().enumerate() {
+            self.radial_integral.compute(k_vector.norm, do_gradients);
+            self.spherical_harmonics.compute(k_vector.direction, do_gradients);
+
+            for l in 0..=self.parameters.max_angular {
+                let spherical_harmonics = self.spherical_harmonics.values.slice(l as isize);
+                let radial_integral = self.radial_integral.values.slice(s![l, ..]);
+
+                for (m, sph_value) in spherical_harmonics.iter().enumerate() {
+                    for (n, ri_value) in radial_integral.iter().enumerate() {
+                        self.k_vector_to_m_n[l][[m, n, ik]] = ri_value * sph_value;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -245,15 +327,24 @@ impl CalculatorBase for LodeSphericalExpansion {
 
     #[time_graph::instrument(name = "LodeSphericalExpansion::compute")]
     fn compute(&mut self, systems: &mut [Box<dyn System>], descriptor: &mut TensorMap) -> Result<(), Error> {
+        let do_gradients = false;
+
+        // TODO: let the user provide the cutoff?
+        // TODO: check atomic_gaussian_width so that we have a non-zero number of k-vectors
+        let k_cutoff = 1.2 * std::f64::consts::PI / self.parameters.atomic_gaussian_width;
 
         for (system_i, system) in systems.iter_mut().enumerate() {
             let cell = system.cell()?;
             if cell.shape() == UnitCell::infinite().shape() {
                 return Err(Error::InvalidParameter("LODE can only be used with periodic systems".into()));
             }
-            let k_vectors = compute_k_vectors(&cell, 1.0);
 
-            let strucfac = compute_structure_factors(system.positions()?, &k_vectors);
+            let k_vectors = compute_k_vectors(&cell, k_cutoff);
+            assert!(!k_vectors.is_empty());
+
+            self.project_k_to_nlm(&k_vectors, do_gradients);
+
+            let structure_factors = compute_structure_factors(system.positions()?, &k_vectors);
         }
         Ok(())
     }
@@ -267,24 +358,25 @@ mod tests {
 
     #[test]
     fn test_compute_structure_factors() {
-        let mut k_vectors = Vec::new();
+        let k_vectors = [
+            KVector{direction: Vector3D::new(1.0, 0.0, 0.0), norm: 1.0},
+            KVector{direction: Vector3D::new(0.0, 1.0, 0.0), norm: 1.0},
+        ];
 
-        k_vectors.push(KVector{vector: Vector3D::new(1.0, 0.0,0.0), norm: 1.0});
-        k_vectors.push(KVector{vector: Vector3D::new(0.0, 1.0, 0.0), norm: 1.0});
-        
-        let positions = [Vector3D::new(1.0, 1.0, 1.0),
-                                        Vector3D::new(2.0, 2.0, 2.0)];
+        let positions = [Vector3D::new(1.0, 1.0, 1.0), Vector3D::new(2.0, 2.0, 2.0)];
 
-        let strucfac = compute_structure_factors(&positions, &k_vectors);
+        let structure_factors = compute_structure_factors(&positions, &k_vectors);
 
-        let ref_real= arr3(
-            &[[[2., 2.], [1.0806046117362793, 1.0806046117362793]],
-                  [[1.0806046117362793, 1.0806046117362793],[2. , 2. ]]]);
-        let ref_imag = arr3(
-            &[[[ 0. ,  0. ], [-1.682941969615793, -1.682941969615793]],
-                  [[1.682941969615793, 1.682941969615793],[ 0. ,  0. ]]]);
+        let expected_real= arr3(&[
+            [[2.0, 2.0], [1.0806046117362793, 1.0806046117362793]],
+            [[1.0806046117362793, 1.0806046117362793], [2.0, 2.0]]
+        ]);
+        let expected_imag = arr3(&[
+            [[0.0, 0.0], [-1.682941969615793, -1.682941969615793]],
+            [[1.682941969615793, 1.682941969615793], [0.0, 0.0]]
+        ]);
 
-        assert_eq!(strucfac.imag, ref_imag);
-        assert_eq!(strucfac.real, ref_real);
+        assert_eq!(structure_factors.real, expected_real);
+        assert_eq!(structure_factors.imag, expected_imag);
     }
 }

--- a/rascaline/src/calculators/soap/gto_radial_integral.rs
+++ b/rascaline/src/calculators/soap/gto_radial_integral.rs
@@ -24,7 +24,7 @@ pub struct GtoParameters {
 }
 
 impl GtoParameters {
-    fn validate(&self) -> Result<(), Error> {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
         if self.max_radial == 0 {
             return Err(Error::InvalidParameter(
                 "max_radial must be at least 1 for GTO radial integral".into()
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn gto_finite_differences() {
+    fn finite_differences() {
         let max_radial = 8;
         let max_angular = 8;
         let gto = SoapGtoRadialIntegral::new(GtoParameters {

--- a/rascaline/src/math/k_vectors.rs
+++ b/rascaline/src/math/k_vectors.rs
@@ -9,8 +9,8 @@ use crate::systems::{UnitCell, CellShape};
 /// A single k-vector and its norm stored together
 #[derive(Debug, Clone)]
 pub struct KVector {
-    /// 3 component k-vector
-    pub vector: Vector3D,
+    /// direction of the k-vector (i.e. normalized vector)
+    pub direction: Vector3D,
     /// length of the k-vector
     pub norm: f64,
 }
@@ -41,9 +41,10 @@ pub fn compute_k_vectors(cell: &UnitCell, k_cutoff: f64) -> Vec<KVector> {
         let k = n3 as f64 * b3;
         let norm_squared = k.norm2();
         if norm_squared < cutoff_squared {
+            let norm = norm_squared.sqrt();
             results.push(KVector {
-                vector: k,
-                norm: norm_squared.sqrt(),
+                direction: k / norm,
+                norm: norm,
             });
         }
     }
@@ -53,9 +54,10 @@ pub fn compute_k_vectors(cell: &UnitCell, k_cutoff: f64) -> Vec<KVector> {
             let k = n2 as f64 * b2 + n3 as f64 * b3;
             let norm_squared = k.norm2();
             if norm_squared < cutoff_squared {
+                let norm = norm_squared.sqrt();
                 results.push(KVector {
-                    vector: k,
-                    norm: norm_squared.sqrt(),
+                    direction: k / norm,
+                    norm: norm,
                 });
             }
         }
@@ -67,9 +69,10 @@ pub fn compute_k_vectors(cell: &UnitCell, k_cutoff: f64) -> Vec<KVector> {
                 let k = n1 as f64 * b1 + n2 as f64 * b2 + n3 as f64 * b3;
                 let norm_squared = k.norm2();
                 if norm_squared < cutoff_squared {
+                    let norm = norm_squared.sqrt();
                     results.push(KVector {
-                        vector: k,
-                        norm: norm_squared.sqrt(),
+                        direction: k / norm,
+                        norm: norm,
                     });
                 }
             }
@@ -83,7 +86,6 @@ pub fn compute_k_vectors(cell: &UnitCell, k_cutoff: f64) -> Vec<KVector> {
 mod tests {
     use super::*;
     use crate::Matrix3;
-    use approx::assert_relative_eq;
 
     const SQRT_3: f64 = 1.7320508075688772;
     const SQRT_5: f64 = 2.23606797749979;
@@ -128,10 +130,8 @@ mod tests {
                 // Check whether number of obtained vectors agrees with exact result
                 assert_eq!(k_vectors.len(), num_vectors_correct[ik]);
 
-                // Check that the obtained normes are indeed the norms of the
-                // corresponding k-vectors and that they lie in the cutoff ball
+                // Check that the norms lie inside the cutoff ball
                 for k_vector in k_vectors {
-                    assert_relative_eq!(k_vector.norm, k_vector.vector.norm(), max_relative = 1e-16);
                     assert!(k_vector.norm < k_cutoff);
                 }
             }


### PR DESCRIPTION
This computes the radial integral and spherical harmonics for the k-vectors. The resulting values agree with pylode [`k_dep_factor_reordered`](https://github.com/ceriottm/lode/blob/fd2b88e3c8110c286bdb9a08908000c3dc0b4b58/src/pylode/lib/projection_coeffs.py#L346-L351) with `G_k` set to 1.0.