### PR TITLE
Show all available python calculators

### DIFF
--- a/docs/src/reference/python/calculators.rst
+++ b/docs/src/reference/python/calculators.rst
@@ -1,15 +1,8 @@
 Available Calculators
 =====================
 
-.. autoclass:: rascaline.SoapPowerSpectrum
-    :show-inheritance:
-
-.. autoclass:: rascaline.SphericalExpansion
-    :show-inheritance:
-
-.. autoclass:: rascaline.SortedDistances
-    :show-inheritance:
-
-
-.. autoclass:: rascaline.calculators.CalculatorBase()
+.. automodule:: rascaline.calculators
     :members:
+    :undoc-members:
+    :exclude-members: DummyCalculator
+    :show-inheritance:


### PR DESCRIPTION
Show all available calculators from the Python API without adding them explicitly.