### PR TITLE
Added selected_keys option to the compute function to allow manual selection of blocks for calculation

### DIFF
--- a/python/rascaline/_c_api.py
+++ b/python/rascaline/_c_api.py
@@ -76,6 +76,7 @@ class rascal_calculation_options_t(ctypes.Structure):
         ("use_native_system", ctypes.c_bool),
         ("selected_samples", rascal_labels_selection_t),
         ("selected_properties", rascal_labels_selection_t),
+        ("selected_keys", POINTER(eqs_labels_t)),
     ]
 
 

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -419,6 +419,172 @@ class TestComputePartialProperties(unittest.TestCase):
         )
 
 
+class TestComputeSelectedKeys(unittest.TestCase):
+    def test_selection_existing(self):
+        system = TestSystem()
+        calculator = DummyCalculator(cutoff=3.2, delta=2, name="")
+
+        # Manually select the keys
+        selected_keys = Labels(
+            names=["species_center"],
+            values=np.array([[1]], dtype=np.int32),
+        )
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_keys=selected_keys
+        )
+
+        self.assertEqual(len(descriptor.keys), 1)
+        self.assertEqual(tuple(descriptor.keys[0]), (1,))
+
+    def test_select_key_not_in_systems(self):
+        system = TestSystem()
+        calculator = DummyCalculator(cutoff=3.2, delta=2, name="")
+
+        # Manually select the keys
+        selected_keys = Labels(
+            names=["species_center"],
+            values=np.array([[4]], dtype=np.int32),
+        )
+        descriptor = calculator.compute(
+            system, use_native_system=False, selected_keys=selected_keys
+        )
+
+        C_block = descriptor.block(species_center=4)
+        self.assertEqual(C_block.values.shape, (0, 2))
+
+    def test_predefined_selection(self):
+        system = TestSystem()
+        calculator = DummyCalculator(cutoff=3.2, delta=2, name="")
+
+        selected_keys = Labels(
+            names=["species_center"],
+            values=np.array([[1]], dtype=np.int32),
+        )
+
+        keys = Labels(
+            names=["species_center"],
+            values=np.array([[1], [8]], dtype=np.int32),
+        )
+
+        # selection from TensorMap
+        selected = [
+            Labels(
+                names=["index_delta", "x_y_z"],
+                values=np.array([[1, 0]], dtype=np.int32),
+            ),
+            Labels(
+                names=["index_delta", "x_y_z"],
+                values=np.array([[0, 1]], dtype=np.int32),
+            ),
+        ]
+        selected_properties = _tensor_map_selection("properties", keys, selected)
+
+        descriptor = calculator.compute(
+            system,
+            use_native_system=False,
+            selected_properties=selected_properties,
+            selected_keys=selected_keys,
+        )
+
+        self.assertEqual(len(descriptor.keys), 1)
+        H_block = descriptor.block(species_center=1)
+        self.assertEqual(H_block.values.shape, (2, 1))
+        self.assertTrue(np.all(H_block.values[0] == (2,)))
+        self.assertTrue(np.all(H_block.values[1] == (3,)))
+
+    def test_name_errors(self):
+        system = TestSystem()
+        calculator = DummyCalculator(cutoff=3.2, delta=2, name="")
+
+        selected_keys = Labels(
+            names=["bad name"],
+            values=np.array([0, 3, 1], dtype=np.int32).reshape(3, 1),
+        )
+
+        with self.assertRaises(RascalError) as cm:
+            calculator.compute(
+                system, use_native_system=False, selected_keys=selected_keys
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "invalid parameter: 'bad name' is not a valid label name",
+        )
+
+        selected_keys = Labels(
+            names=["bad_name"],
+            values=np.array([0, 3, 1], dtype=np.int32).reshape(3, 1),
+        )
+
+        with self.assertRaises(RascalError) as cm:
+            calculator.compute(
+                system, use_native_system=False, selected_keys=selected_keys
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "invalid parameter: names for the keys of the calculator "
+            "[species_center] and selected keys [bad_name] do not match",
+        )
+
+    def test_key_errors(self):
+        system = TestSystem()
+        calculator = DummyCalculator(cutoff=3.2, delta=2, name="")
+
+        selected_keys = Labels(
+            names=["species_center"],
+            values=np.empty((0, 1), dtype=np.int32),
+        )
+
+        with self.assertRaises(RascalError) as cm:
+            calculator.compute(
+                system, use_native_system=False, selected_keys=selected_keys
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "invalid parameter: selected keys can not be empty",
+        )
+
+        # in the case of selected_properies/selected_samples and selected_keys
+        # the selected keys must be in the keys of the predefined tensor_map
+        selected_keys = Labels(
+            names=["species_center"],
+            values=np.array([[4]], dtype=np.int32),
+        )
+
+        keys = Labels(
+            names=["species_center"],
+            values=np.array([[1], [8]], dtype=np.int32),
+        )
+
+        # selection from TensorMap
+        selected = [
+            Labels(
+                names=["index_delta", "x_y_z"],
+                values=np.array([[1, 0]], dtype=np.int32),
+            ),
+            Labels(
+                names=["index_delta", "x_y_z"],
+                values=np.array([[0, 1]], dtype=np.int32),
+            ),
+        ]
+        selected_properties = _tensor_map_selection("properties", keys, selected)
+
+        with self.assertRaises(RascalError) as cm:
+            calculator.compute(
+                system,
+                use_native_system=False,
+                selected_properties=selected_properties,
+                selected_keys=selected_keys,
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "invalid parameter: expected a key [4] in predefined properties selection",
+        )
+
+
 class TestSortedDistances(unittest.TestCase):
     def test_name(self):
         calculator = SortedDistances(

--- a/rascaline-c-api/include/rascaline.h
+++ b/rascaline-c-api/include/rascaline.h
@@ -314,6 +314,13 @@ typedef struct rascal_calculation_options_t {
    * Selection of properties to compute for the samples
    */
   struct rascal_labels_selection_t selected_properties;
+  /**
+   * Selection for the keys to include in the output. Set this parameter to
+   * `NULL` to use the default set of keys, as determined by the calculator.
+   * Note that this default set of keys can depend on which systems we are
+   * running the calculation on.
+   */
+  const eqs_labels_t *selected_keys;
 } rascal_calculation_options_t;
 
 #ifdef __cplusplus

--- a/rascaline/src/calculators/dummy_calculator.rs
+++ b/rascaline/src/calculators/dummy_calculator.rs
@@ -245,9 +245,10 @@ mod tests {
 
         let samples = Labels::new(["structure", "center"], &[[0, 1]]);
         let properties = Labels::new(["index_delta", "x_y_z"], &[[0, 1]]);
+        let keys = Labels::new(["species_center"], &[[0], [1], [6], [-42]]);
 
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut systems, &samples, &properties
+            calculator, &mut systems, &keys, &samples, &properties
         );
     }
 }

--- a/rascaline/src/calculators/lode/spherical_expansion.rs
+++ b/rascaline/src/calculators/lode/spherical_expansion.rs
@@ -388,7 +388,12 @@ impl LodeSphericalExpansion {
                     0.into(),
                     species[center_i].into(),
                     species[center_i].into(),
-                ]).expect("missing block");
+                ]);
+
+                if block_i.is_none() {
+                    continue;
+                }
+                let block_i = block_i.expect("we just checked");
 
                 let mut block = descriptor.block_mut_by_id(block_i);
                 let values = block.values_mut();
@@ -627,7 +632,14 @@ impl CalculatorBase for LodeSphericalExpansion {
                                 spherical_harmonics_l.into(),
                                 species[center_i].into(),
                                 species_neighbor.into(),
-                            ]).expect("missing block");
+                            ]);
+
+                            if block_i.is_none() {
+                                continue;
+                            }
+                            let block_i = block_i.expect("we just checked");
+
+
                             let mut block = descriptor.block_mut_by_id(block_i);
                             let values = block.values_mut();
                             let mut array = array_mut_for_system(&mut values.data);
@@ -802,7 +814,7 @@ mod tests {
                 cutoff: 1.0,
                 k_cutoff: None,
                 max_radial: 4,
-                max_angular: 4,
+                max_angular: 2,
                 atomic_gaussian_width: 1.0,
                 center_atom_weight: 1.0,
                 radial_basis: RadialBasis::splined_gto(1e-8),
@@ -824,8 +836,24 @@ mod tests {
             [0, 2],
         ]);
 
+        let keys = Labels::new(["spherical_harmonics_l", "species_center", "species_neighbor"], &[
+            [0, -42, -42],
+            [0, 6, 1], // not part of the default keys
+            [2, -42, -42],
+            [1, -42, -42],
+            [1, -42, 1],
+            [1, 1, -42],
+            [0, -42, 1],
+            [2, -42, 1],
+            [0, 1, 1],
+            [1, 1, 1],
+            [0, 1, -42],
+            [2, 1, -42],
+            [2, 1, 1],
+        ]);
+
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut [Box::new(system)], &samples, &properties
+            calculator, &mut [Box::new(system)], &keys, &samples, &properties
         );
     }
 

--- a/rascaline/src/calculators/soap/power_spectrum.rs
+++ b/rascaline/src/calculators/soap/power_spectrum.rs
@@ -265,13 +265,13 @@ impl SoapPowerSpectrum {
             let block_id_1 = spherical_expansion.keys().position(&[
                 first_l, species_center, species_neighbor_1
             ]).expect("missing block in spherical expansion");
-            let spx_block_1 = &spherical_expansion.blocks()[block_id_1];
+            let spx_block_1 = &spherical_expansion.block_by_id(block_id_1);
             let spx_samples_1 = &spx_block_1.values().samples;
 
             let block_id_2 = spherical_expansion.keys().position(&[
                 first_l, species_center, species_neighbor_2
             ]).expect("missing block in spherical expansion");
-            let spx_block_2 = &spherical_expansion.blocks()[block_id_2];
+            let spx_block_2 = &spherical_expansion.block_by_id(block_id_2);
             let spx_samples_2 = &spx_block_2.values().samples;
 
             values_mapping.reserve(values.samples.count());
@@ -321,12 +321,12 @@ impl SoapPowerSpectrum {
             let block_1 = spherical_expansion.keys().position(
                 &[l, species_center, species_neighbor_1]
             ).expect("missing first neighbor species block in spherical expansion");
-            let block_1 = &spherical_expansion.blocks()[block_1];
+            let block_1 = &spherical_expansion.block_by_id(block_1);
 
             let block_2 = spherical_expansion.keys().position(
                 &[l, species_center, species_neighbor_2]
             ).expect("missing second neighbor species block in spherical expansion");
-            let block_2 = &spherical_expansion.blocks()[block_2];
+            let block_2 = &spherical_expansion.block_by_id(block_2);
 
             let values_1 = block_1.values().data.as_array();
             let values_2 = block_2.values().data.as_array();
@@ -518,6 +518,7 @@ impl CalculatorBase for SoapPowerSpectrum {
             gradients: &gradients,
             selected_samples: LabelsSelection::Predefined(&selected),
             selected_properties: LabelsSelection::Predefined(&selected),
+            selected_keys: Some(selected.keys()),
             ..Default::default()
         };
 
@@ -807,7 +808,7 @@ mod tests {
             parameters()
         ).unwrap()) as Box<dyn CalculatorBase>);
 
-        let mut systems = test_systems(&["water", "methane"]);
+        let mut systems = test_systems(&["methane"]);
 
         let properties = Labels::new(["l", "n1", "n2"], &[
             [0, 0, 1],
@@ -819,14 +820,22 @@ mod tests {
         ]);
 
         let samples = Labels::new(["structure", "center"], &[
-            [0, 1],
             [0, 2],
-            [1, 0],
-            [1, 2],
+            [0, 1],
+        ]);
+
+        let keys = Labels::new(["species_center", "species_neighbor_1", "species_neighbor_2"], &[
+            [1, 1, 1],
+            [6, 6, 6],
+            [1, 8, 6], // not part of the default keys
+            [1, 6, 6],
+            [1, 1, 6],
+            [6, 1, 1],
+            [6, 1, 6],
         ]);
 
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut systems, &samples, &properties
+            calculator, &mut systems, &keys, &samples, &properties
         );
     }
 

--- a/rascaline/src/calculators/soap/radial_spectrum.rs
+++ b/rascaline/src/calculators/soap/radial_spectrum.rs
@@ -223,6 +223,7 @@ impl CalculatorBase for SoapRadialSpectrum {
             gradients: &gradients,
             selected_samples: LabelsSelection::Predefined(&selected),
             selected_properties: LabelsSelection::Predefined(&selected),
+            selected_keys: Some(selected.keys()),
             ..Default::default()
         };
 
@@ -365,13 +366,24 @@ mod tests {
         ]);
 
         let samples = Labels::new(["structure", "center"], &[
+            [1, 0],
             [0, 1],
             [0, 0],
-            [1, 0],
+        ]);
+
+        let keys = Labels::new(["species_center", "species_neighbor"], &[
+            [1, 1],
+            [9, 1], // not part of the default keys
+            [-42, 1],
+            [1, -42],
+            [1, 6],
+            [-42, -42],
+            [6, 1],
+            [6, 6],
         ]);
 
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut systems, &samples, &properties,
+            calculator, &mut systems, &keys, &samples, &properties,
         );
     }
 }

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -769,7 +769,7 @@ mod tests {
                         l.into(), species_center.into() , species_neighbor.into()
                     ]);
                     assert!(block_i.is_some());
-                    let block = &descriptor.blocks()[block_i.unwrap()];
+                    let block = &descriptor.block_by_id(block_i.unwrap());
                     let array = block.values().data.as_array();
                     assert_eq!(array.shape().len(), 3);
                     assert_eq!(array.shape()[1], 2 * l + 1);
@@ -814,10 +814,13 @@ mod tests {
     #[test]
     fn compute_partial() {
         let calculator = Calculator::from(Box::new(SphericalExpansion::new(
-            parameters()
+            SphericalExpansionParameters {
+                max_angular: 2,
+                ..parameters()
+            }
         ).unwrap()) as Box<dyn CalculatorBase>);
 
-        let mut systems = test_systems(&["water", "methane"]);
+        let mut systems = test_systems(&["water"]);
 
         let properties = Labels::new(["n"], &[
             [0],
@@ -826,14 +829,28 @@ mod tests {
         ]);
 
         let samples = Labels::new(["structure", "center"], &[
-            [0, 1],
             [0, 2],
-            [1, 0],
-            [1, 2],
+            [0, 1],
+        ]);
+
+        let keys = Labels::new(["spherical_harmonics_l", "species_center", "species_neighbor"], &[
+            [0, -42, -42],
+            [0, 6, 1], // not part of the default keys
+            [2, -42, -42],
+            [1, -42, -42],
+            [1, -42, 1],
+            [1, 1, -42],
+            [0, -42, 1],
+            [2, -42, 1],
+            [0, 1, 1],
+            [1, 1, 1],
+            [0, 1, -42],
+            [2, 1, -42],
+            [2, 1, 1],
         ]);
 
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut systems, &samples, &properties
+            calculator, &mut systems, &keys, &samples, &properties
         );
     }
 

--- a/rascaline/src/calculators/sorted_distances.rs
+++ b/rascaline/src/calculators/sorted_distances.rs
@@ -225,11 +225,12 @@ mod tests {
 
         let mut systems = test_systems(&["water"]);
 
+        let keys = Labels::new(["species_center"], &[[1], [6], [8], [-42]]);
         let samples = Labels::new(["structure", "center"], &[[0, 1]]);
         let properties = Labels::new(["neighbor"], &[[2], [0]]);
 
         crate::calculators::tests_utils::compute_partial(
-            calculator, &mut systems, &samples, &properties
+            calculator, &mut systems, &keys, &samples, &properties
         );
     }
 }

--- a/rascaline/src/tutorials/moments/s3_compute_3.rs
+++ b/rascaline/src/tutorials/moments/s3_compute_3.rs
@@ -69,24 +69,32 @@ impl CalculatorBase for GeometricMoments {
                 // get the block where the first atom is the center
                 let first_block_id = descriptor.keys().position(&[
                     species[pair.first].into(), species[pair.second].into(),
-                ]).expect("missing block for the first atom");
-                let first_block = &descriptor.blocks()[first_block_id];
+                ]);
+
+                // get the sample corresponding to the first atom as a center
+                //
+                // This will be `None` if the block or samples are not present
+                // in the descriptor, i.e. if the user did not request them.
+                let first_sample_position = if let Some(block_id) = first_block_id {
+                    descriptor.block_by_id(block_id).values().samples.position(&[
+                        system_i.into(), pair.first.into()
+                    ])
+                } else {
+                    None
+                };
 
                 // get the id of the block where the second atom is the center
                 let second_block_id = descriptor.keys().position(&[
                     species[pair.second].into(), species[pair.first].into(),
-                ]).expect("missing block for the second atom");
-                let second_block = &descriptor.blocks()[second_block_id];
-
-                // get the positions of the samples in their respective blocks.
-                // These variables will be `None` if the samples are not present
-                // in the blocks, i.e. if the user did not request them.
-                let first_sample_position = first_block.values().samples.position(&[
-                    system_i.into(), pair.first.into()
                 ]);
-                let second_sample_position = second_block.values().samples.position(&[
-                    system_i.into(), pair.second.into()
-                ]);
+                // get the sample corresponding to the first atom as a center
+                let second_sample_position = if let Some(block_id) = second_block_id {
+                    descriptor.block_by_id(block_id).values().samples.position(&[
+                        system_i.into(), pair.second.into()
+                    ])
+                } else {
+                    None
+                };
 
                 // skip calculation if neither of the samples is present
                 if first_sample_position.is_none() && second_sample_position.is_none() {

--- a/rascaline/src/tutorials/moments/s3_compute_4.rs
+++ b/rascaline/src/tutorials/moments/s3_compute_4.rs
@@ -11,8 +11,8 @@ use crate::calculators::CalculatorBase;
 // these are here just to make the code below compile
 const first_sample_position: Option<usize> = None;
 const second_sample_position: Option<usize> = None;
-const first_block_id: usize = 0;
-const second_block_id: usize = 0;
+const first_block_id: Option<usize> = None;
+const second_block_id: Option<usize> = None;
 
 #[derive(Clone, Debug)]
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -74,7 +74,8 @@ impl CalculatorBase for GeometricMoments {
                 let n_neighbors_second = system.pairs_containing(pair.second)?.len() as f64;
 
                 if let Some(sample_i) = first_sample_position {
-                    let mut block = descriptor.block_mut_by_id(first_block_id);
+                    let block_id = first_block_id.expect("we have a sample in this block");
+                    let mut block = descriptor.block_mut_by_id(block_id);
                     let values = block.values_mut();
                     let array = values.data.as_array_mut();
 
@@ -85,7 +86,8 @@ impl CalculatorBase for GeometricMoments {
                 }
 
                 if let Some(sample_i) = second_sample_position {
-                    let mut block = descriptor.block_mut_by_id(second_block_id);
+                    let block_id = second_block_id.expect("we have a sample in this block");
+                    let mut block = descriptor.block_mut_by_id(block_id);
                     let values = block.values_mut();
                     let array = values.data.as_array_mut();
 

--- a/rascaline/src/tutorials/moments/s3_compute_5.rs
+++ b/rascaline/src/tutorials/moments/s3_compute_5.rs
@@ -10,8 +10,8 @@ use crate::calculators::CalculatorBase;
 // these are here just to make the code below compile
 const first_sample_position: Option<usize> = None;
 const second_sample_position: Option<usize> = None;
-const first_block_id: usize = 0;
-const second_block_id: usize = 0;
+const first_block_id: Option<usize> = None;
+const second_block_id: Option<usize> = None;
 const n_neighbors_first: f64 = 0.0;
 const n_neighbors_second: f64 = 0.0;
 
@@ -86,7 +86,9 @@ impl CalculatorBase for GeometricMoments {
                     }
 
                     if let Some(sample_position) = first_sample_position {
-                        let mut block = descriptor.block_mut_by_id(first_block_id);
+                        let block_id = first_block_id.expect("we have a sample in this block");
+                        let mut block = descriptor.block_mut_by_id(block_id);
+
                         let gradient = block.gradient_mut("positions").expect("missing gradient storage");
                         let array = gradient.data.as_array_mut();
 
@@ -118,7 +120,9 @@ impl CalculatorBase for GeometricMoments {
                     }
 
                     if let Some(sample_position) = second_sample_position {
-                        let mut block = descriptor.block_mut_by_id(second_block_id);
+                        let block_id = second_block_id.expect("we have a sample in this block");
+                        let mut block = descriptor.block_mut_by_id(block_id);
+
                         let gradient = block.gradient_mut("positions").expect("missing gradient storage");
                         let array = gradient.data.as_array_mut();
 


### PR DESCRIPTION
Hi all! This PR has added a new option `selected_keys` to the `compute` function. It allows the user to manually select the keys whose blocks will be computed by the algorithm. All relevant tests have been added. 