### PR TITLE
Add how_to on the keys selection

### DIFF
--- a/docs/src/how-to/index.rst
+++ b/docs/src/how-to/index.rst
@@ -13,3 +13,4 @@ are a total beginner, you can go to :ref:`userdoc-get-started` section.
     computing-soap
     sample-selection
     property-selection
+    keys-selection

--- a/docs/src/how-to/keys-selection.rst
+++ b/docs/src/how-to/keys-selection.rst
@@ -1,0 +1,48 @@
+Keys Selection
+==============
+
+This examples shows how to compute a set of blocks which correspond to p
+redefined keys.
+
+This is useful, for example, in 2 cases: when we are interested in analyzing
+only some of the blocks (so there is no need to generate the rest, wasting
+resources on this), and when we, on the contrary, need to explicitly add some
+blocks to the resulting descriptor (to match the machine learning model, for
+instance).
+
+This example uses the functions discussed in
+:ref:`userdoc-how-to-computing-soap` and
+:ref:`userdoc-how-to-property-selection`, so we suggest that you read it
+initially.
+
+You can obtain a testing dataset from our :download:`website <../../static/dataset.xyz>`.
+
+.. tabs::
+
+    .. group-tab:: Python
+
+        .. container:: sphx-glr-footer sphx-glr-footer-example
+
+            .. container:: sphx-glr-download sphx-glr-download-python
+
+                :download:`Download Python source code for this example: keys-selection.py <../examples/keys-selection.py>`
+
+            .. container:: sphx-glr-download sphx-glr-download-jupyter
+
+                :download:`Download Jupyter notebook for this example: keys-selection.ipynb <../examples/keys-selection.ipynb>`
+
+        .. include:: ../examples/keys-selection.rst
+            :start-after: start-body
+            :end-before: end-body
+
+    .. group-tab:: Rust
+
+        To be done
+
+    .. group-tab:: C++
+
+        To be done
+
+    .. group-tab:: C
+
+        To be done

--- a/docs/src/how-to/keys-selection.rst
+++ b/docs/src/how-to/keys-selection.rst
@@ -1,19 +1,16 @@
-Keys Selection
+Keys selection
 ==============
 
-This examples shows how to compute a set of blocks which correspond to p
-redefined keys.
+This examples shows how to tell rascaline to compute a set of blocks which
+correspond to predefined keys. This can be used to either reduce the set of
+computed blocks if we are only interested in some of them (skipping the
+calculation of the other blocks); or when we need to explicitly add some blocks
+to the resulting descriptor (for example to match the block set of an already
+trained machine learning model).
 
-This is useful, for example, in 2 cases: when we are interested in analyzing
-only some of the blocks (so there is no need to generate the rest, wasting
-resources on this), and when we, on the contrary, need to explicitly add some
-blocks to the resulting descriptor (to match the machine learning model, for
-instance).
-
-This example uses the functions discussed in
-:ref:`userdoc-how-to-computing-soap` and
-:ref:`userdoc-how-to-property-selection`, so we suggest that you read it
-initially.
+This example uses functions discussed in :ref:`userdoc-how-to-computing-soap`
+and :ref:`userdoc-how-to-property-selection`, so we suggest that you read these
+first.
 
 You can obtain a testing dataset from our :download:`website <../../static/dataset.xyz>`.
 

--- a/docs/src/how-to/property-selection.rst
+++ b/docs/src/how-to/property-selection.rst
@@ -1,3 +1,5 @@
+.. _userdoc-how-to-property-selection:
+
 Property Selection
 ==================
 

--- a/python/examples/keys-selection.py
+++ b/python/examples/keys-selection.py
@@ -40,18 +40,17 @@ calculator = SoapPowerSpectrum(**HYPER_PARAMETERS)
 
 # %%
 #
-# The selections for keys can be a set of ``Labels``, with the names
-# of the keys being a subset of the names of the keys produced by the
-# calculator.
+# The selections for keys should be a set of ``Labels``, with the names of the
+# keys being a subset of the names of the keys produced by the calculator.
 
 descriptor = calculator.compute(frames)
 print("keys names:", descriptor.keys.names)
 
 # %%
 #
-# We can use a set of these names to define a selection. In this case, only
-# blocks matching the labels in this selection will be used by rascaline
-# (here, only blocks with keys ``[1,1,1]`` and ``[4,4,4]`` will be calculated)
+# We can use these names to define a selection, and only blocks matching the
+# labels in this selection will be used by rascaline. Here, only blocks with
+# keys ``[1,1,1]`` and ``[4,4,4]`` will be calculated.
 
 selection = Labels(
     names=["species_center", "species_neighbor_1", "species_neighbor_2"],
@@ -61,30 +60,29 @@ selected_descriptor = calculator.compute(frames, selected_keys=selection)
 
 # %%
 #
-# We get a TensorMap with 2 blocks:
+# We get a TensorMap with 2 blocks, corresponding to the requested keys
 
 print(selected_descriptor.keys)
 
 # %%
 #
-# In this case, the block ``[1,1,1]`` contained in the original ``TensorMap``
-# will be exactly the same:
+# The block for ``[1, 1, 1]`` will be exactly the same as the one in the full
+# ``TensorMap``
 answer = np.array_equal(descriptor.block(0).values, selected_descriptor.block(0).values)
 print(f"Are the blocks 0 in the descriptor and selected_descriptor equal? {answer}")
 
 # %%
 #
-# And the form of the block ``[4,4,4]``, which is not created by default,
-# will be 0,180, that is, an empty block with the required key and set of
-# properties was generated
+# Since there is no block for ``[4, 4, 4]`` in the full ``TensorMap``, an empty
+# block with no samples and the default set of properties is generated
 
 print(selected_descriptor.block(1).values.shape)
 
 # %%
 #
-# In addition, ``selected_keys`` can be used simultaneously with other
-# selectors. To do this, create ``TensorMap`` below, which we will pass
-# as ``selected_properties``:
+# ``selected_keys`` can be used simultaneously with samples and properties
+# selection. Here we define a selection for properties as a ``TensorMap`` to
+# select different properties for each block:
 
 selection = [
     Labels(names=["l", "n1", "n2"], values=np.array([[0, 0, 0]])),
@@ -110,8 +108,8 @@ selected_properties = TensorMap(keys, blocks)
 
 # %%
 #
-# As ``selected_keys`` we will take only 1 of the keys that were in
-# ``selected_properties``
+# Only one of the key from our ``selected_properties`` will be used in the
+# ``selected_keys``, meaning the output will only contain this one key/block.
 
 selected_keys = Labels(
     names=["species_center", "species_neighbor_1", "species_neighbor_2"],
@@ -126,8 +124,8 @@ descriptor = calculator.compute(
 
 # %%
 #
-# As a result, we get 1 block with values of the form (420, 1), that is, with
-# only 1 property
+# As expected, we get 1 block with values of the form (420, 1), i.e. with only 1
+# property.
 
 print(f"list of keys: {descriptor.keys}")
 print(descriptor.block(0).values.shape)

--- a/python/examples/keys-selection.py
+++ b/python/examples/keys-selection.py
@@ -38,15 +38,14 @@ HYPER_PARAMETERS = {
 
 calculator = SoapPowerSpectrum(**HYPER_PARAMETERS)
 
-descriptor = calculator.compute(frames)
-
 # %%
 #
-# The selections for keys can be a set of ``Labels``, in which case the names
-# of the keys must be a set of the names of the keys produced by the
-# calculator. You can see the default set of names with:
+# The selections for keys can be a set of ``Labels``, with the names
+# of the keys being a subset of the names of the keys produced by the
+# calculator.
 
-print("properties names:", descriptor.keys.names)
+descriptor = calculator.compute(frames)
+print("keys names:", descriptor.keys.names)
 
 # %%
 #

--- a/python/examples/keys-selection.py
+++ b/python/examples/keys-selection.py
@@ -1,0 +1,138 @@
+"""
+Keys Selection
+==============
+
+.. start-body
+"""
+import chemfiles
+import numpy as np
+from equistore import Labels, TensorBlock, TensorMap
+
+from rascaline import SoapPowerSpectrum
+
+
+# %%
+#
+# First we load the dataset with chemfiles
+
+with chemfiles.Trajectory("dataset.xyz") as trajectory:
+    frames = [f for f in trajectory]
+
+# %%
+#
+# and define the hyper parameters of the representation
+
+HYPER_PARAMETERS = {
+    "cutoff": 5.0,
+    "max_radial": 6,
+    "max_angular": 4,
+    "atomic_gaussian_width": 0.3,
+    "center_atom_weight": 1.0,
+    "radial_basis": {
+        "Gto": {},
+    },
+    "cutoff_function": {
+        "ShiftedCosine": {"width": 0.5},
+    },
+}
+
+calculator = SoapPowerSpectrum(**HYPER_PARAMETERS)
+
+descriptor = calculator.compute(frames)
+
+# %%
+#
+# The selections for keys can be a set of ``Labels``, in which case the names
+# of the keys must be a set of the names of the keys produced by the
+# calculator. You can see the default set of names with:
+
+print("properties names:", descriptor.keys.names)
+
+# %%
+#
+# We can use a set of these names to define a selection. In this case, only
+# blocks matching the labels in this selection will be used by rascaline
+# (here, only blocks with keys ``[1,1,1]`` and ``[4,4,4]`` will be calculated)
+
+selection = Labels(
+    names=["species_center", "species_neighbor_1", "species_neighbor_2"],
+    values=np.array([[1, 1, 1], [4, 4, 4]], dtype=np.int32),
+)
+selected_descriptor = calculator.compute(frames, selected_keys=selection)
+
+# %%
+#
+# We get a TensorMap with 2 blocks:
+
+print(selected_descriptor.keys)
+
+# %%
+#
+# In this case, the block ``[1,1,1]`` contained in the original ``TensorMap``
+# will be exactly the same:
+answer = np.array_equal(descriptor.block(0).values, selected_descriptor.block(0).values)
+print(f"Are the blocks 0 in the descriptor and selected_descriptor equal? {answer}")
+
+# %%
+#
+# And the form of the block ``[4,4,4]``, which is not created by default,
+# will be 0,180, that is, an empty block with the required key and set of
+# properties was generated
+
+print(selected_descriptor.block(1).values.shape)
+
+# %%
+#
+# In addition, ``selected_keys`` can be used simultaneously with other
+# selectors. To do this, create ``TensorMap`` below, which we will pass
+# as ``selected_properties``:
+
+selection = [
+    Labels(names=["l", "n1", "n2"], values=np.array([[0, 0, 0]])),
+    Labels(names=["l", "n1", "n2"], values=np.array([[1, 1, 1]])),
+]
+blocks = []
+for entries in selection:
+    blocks.append(
+        TensorBlock(
+            values=np.empty((len(entries), 1)),
+            samples=Labels.single(),
+            components=[],
+            properties=entries,
+        )
+    )
+
+keys = Labels(
+    names=["species_center", "species_neighbor_1", "species_neighbor_2"],
+    values=np.array([[1, 1, 1], [8, 8, 8]], dtype=np.int32),
+)
+
+selected_properties = TensorMap(keys, blocks)
+
+# %%
+#
+# As ``selected_keys`` we will take only 1 of the keys that were in
+# ``selected_properties``
+
+selected_keys = Labels(
+    names=["species_center", "species_neighbor_1", "species_neighbor_2"],
+    values=np.array([[1, 1, 1]], dtype=np.int32),
+)
+
+descriptor = calculator.compute(
+    frames,
+    selected_properties=selected_properties,
+    selected_keys=selected_keys,
+)
+
+# %%
+#
+# As a result, we get 1 block with values of the form (420, 1), that is, with
+# only 1 property
+
+print(f"list of keys: {descriptor.keys}")
+print(descriptor.block(0).values.shape)
+
+# %%
+#
+# .. end-body


### PR DESCRIPTION
Hi all, this PR contains a how_to example for the new attribute of calculator `selected_keys`, added in #134  