### PR TITLE
Reduce the number of equistore access in spherical expansion

### DIFF
--- a/rascaline-c-api/src/lib.rs
+++ b/rascaline-c-api/src/lib.rs
@@ -3,7 +3,7 @@
 // disable some style lints
 #![allow(clippy::needless_return, clippy::redundant_field_names, clippy::upper_case_acronyms)]
 #![allow(clippy::missing_errors_doc, clippy::missing_safety_doc, clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
+#![allow(clippy::must_use_candidate, clippy::uninlined_format_args)]
 
 mod utils;
 #[macro_use]

--- a/rascaline-c-api/tests/utils/mod.rs
+++ b/rascaline-c-api/tests/utils/mod.rs
@@ -8,8 +8,8 @@ pub fn cmake_config(source_dir: &Path, build_dir: &Path, build_type: &str) -> Co
     let cmake = which::which("cmake").expect("could not find cmake");
 
     let mut cmake_config = Command::new(cmake);
-    cmake_config.current_dir(&build_dir);
-    cmake_config.arg(&source_dir);
+    cmake_config.current_dir(build_dir);
+    cmake_config.arg(source_dir);
 
     // the cargo executable currently running
     let cargo_exe = std::env::var("CARGO").expect("CARGO env var is not set");
@@ -33,7 +33,7 @@ pub fn cmake_build(build_dir: &Path, build_type: &str) -> Command {
     let cmake = which::which("cmake").expect("could not find cmake");
 
     let mut cmake_build = Command::new(cmake);
-    cmake_build.current_dir(&build_dir);
+    cmake_build.current_dir(build_dir);
     cmake_build.arg("--build");
     cmake_build.arg(".");
     cmake_build.arg("--config");

--- a/rascaline/benches/lode-spherical-expansion.rs
+++ b/rascaline/benches/lode-spherical-expansion.rs
@@ -5,7 +5,7 @@ use criterion::{BenchmarkGroup, Criterion, measurement::WallTime, SamplingMode};
 use criterion::{criterion_group, criterion_main};
 
 fn load_systems(path: &str) -> Vec<Box<dyn System>> {
-    let systems = rascaline::systems::read_from_file(&format!("benches/data/{}", path))
+    let systems = rascaline::systems::read_from_file(format!("benches/data/{}", path))
         .expect("failed to read file");
 
     return systems.into_iter()

--- a/rascaline/benches/soap-power-spectrum.rs
+++ b/rascaline/benches/soap-power-spectrum.rs
@@ -7,7 +7,7 @@ use criterion::{criterion_group, criterion_main};
 
 
 fn load_systems(path: &str) -> Vec<Box<dyn System>> {
-    let systems = rascaline::systems::read_from_file(&format!("benches/data/{}", path))
+    let systems = rascaline::systems::read_from_file(format!("benches/data/{}", path))
         .expect("failed to read file");
 
     return systems.into_iter()

--- a/rascaline/benches/soap-spherical-expansion.rs
+++ b/rascaline/benches/soap-spherical-expansion.rs
@@ -5,7 +5,7 @@ use criterion::{BenchmarkGroup, Criterion, measurement::WallTime, SamplingMode};
 use criterion::{criterion_group, criterion_main};
 
 fn load_systems(path: &str) -> Vec<Box<dyn System>> {
-    let systems = rascaline::systems::read_from_file(&format!("benches/data/{}", path))
+    let systems = rascaline::systems::read_from_file(format!("benches/data/{}", path))
         .expect("failed to read file");
 
     return systems.into_iter()

--- a/rascaline/src/calculators/dummy_calculator.rs
+++ b/rascaline/src/calculators/dummy_calculator.rs
@@ -210,7 +210,7 @@ mod tests {
         let mut calculator = Calculator::from(Box::new(DummyCalculator{
             cutoff: 1.0,
             delta: 9,
-            name: "".into(),
+            name: String::new(),
         }) as Box<dyn CalculatorBase>);
 
         let mut systems = test_systems(&["water"]);
@@ -239,7 +239,7 @@ mod tests {
         let calculator = Calculator::from(Box::new(DummyCalculator{
             cutoff: 1.0,
             delta: 9,
-            name: "".into(),
+            name: String::new(),
         }) as Box<dyn CalculatorBase>);
         let mut systems = test_systems(&["water"]);
 

--- a/rascaline/src/calculators/mod.rs
+++ b/rascaline/src/calculators/mod.rs
@@ -84,7 +84,6 @@ pub use self::radial_basis::{RadialBasis, GtoRadialBasis};
 
 mod descriptors_by_systems;
 pub(crate) use self::descriptors_by_systems::{array_mut_for_system, split_tensor_map_by_system};
-pub(crate) use self::descriptors_by_systems::TensorMapView;
 
 pub mod soap;
 pub use self::soap::{SphericalExpansion, SphericalExpansionParameters};

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -1,14 +1,14 @@
 use std::cell::RefCell;
 use std::sync::Arc;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use thread_local::ThreadLocal;
 
-use ndarray::{Array2, Array3, s};
+use ndarray::s;
 use rayon::prelude::*;
 
-use equistore::{LabelsBuilder, Labels, LabelValue};
-use equistore::{TensorMap, TensorBlockRefMut};
+use equistore::{LabelsBuilder, Labels, LabelValue, TensorBlockRefMut};
+use equistore::TensorMap;
 
 use crate::{Error, System, Vector3D, Matrix3};
 use crate::systems::CellShape;
@@ -25,7 +25,7 @@ use super::radial_integral::SoapRadialIntegralParameters;
 use super::{CutoffFunction, RadialScaling};
 use crate::calculators::radial_basis::RadialBasis;
 
-use super::super::{split_tensor_map_by_system, array_mut_for_system, TensorMapView};
+use super::super::{split_tensor_map_by_system, array_mut_for_system};
 
 const FOUR_PI: f64 = 4.0 * std::f64::consts::PI;
 
@@ -61,24 +61,6 @@ pub struct SphericalExpansionParameters {
     /// model
     #[serde(default)]
     pub radial_scaling: RadialScaling,
-}
-
-/// A single pair involved in the calculation of spherical expansion
-struct Pair {
-    /// Sample associated with the first atom in the pair (`[system, first_atom]`)
-    first_sample: [LabelValue; 2],
-    /// Sample associated with the second atom in the pair (`[system, second_atom]`)
-    second_sample: [LabelValue; 2],
-    /// species of the first atom in the pair
-    first_species: i32,
-    /// species of the second atom in the pair
-    second_species: i32,
-    /// distance between the atoms in the pair
-    distance: f64,
-    /// normalized direction vector from the first to the second atom
-    direction: Vector3D,
-    /// full vector from the first to the second atom
-    vector: Vector3D,
 }
 
 /// The actual calculator used to compute SOAP spherical expansion coefficients
@@ -234,13 +216,12 @@ impl SphericalExpansion {
     /// as the center and `pair.second` as the neighbor, and for the spherical
     /// expansion with `pair.second` as the center and `pair.first` as the
     /// neighbor.
-    #[allow(clippy::too_many_lines)]
     fn compute_for_pair(
         &self,
-        pair: &Pair,
-        descriptor: &mut TensorMapView,
+        distance: f64,
+        direction: Vector3D,
         do_gradients: GradientsOptions,
-        inverse_cell: &Matrix3,
+        contribution: &mut PairContribution,
     ) {
         let mut radial_integral = self.radial_integral.get_or(|| {
             let radial_integral = SoapRadialIntegralCache::new(
@@ -259,51 +240,15 @@ impl SphericalExpansion {
             RefCell::new(SphericalHarmonicsCache::new(self.parameters.max_angular))
         }).borrow_mut();
 
-        radial_integral.compute(pair.distance, do_gradients.either());
-        spherical_harmonics.compute(pair.direction, do_gradients.either());
+        radial_integral.compute(distance, do_gradients.either());
+        spherical_harmonics.compute(direction, do_gradients.either());
 
-        let f_scaling = self.scaling_functions(pair.distance);
-        let f_scaling_grad = self.scaling_functions_gradient(pair.distance);
+        let f_scaling = self.scaling_functions(distance);
+        let f_scaling_grad = self.scaling_functions_gradient(distance);
 
-        // Cache allocation for coefficients & gradients
-        let shape = (2 * self.parameters.max_angular + 1, self.parameters.max_radial);
-        let mut coefficients = Array2::from_elem(shape, 0.0);
-        let mut coefficients_grad = if do_gradients.either() {
-            let shape = (3, 2 * self.parameters.max_angular + 1, self.parameters.max_radial);
-            Some(Array3::from_elem(shape, 0.0))
-        } else {
-            None
-        };
-
-        let inverse_cell_pair_vector = Vector3D::new(
-            pair.vector[0] * inverse_cell[0][0] + pair.vector[1] * inverse_cell[1][0] + pair.vector[2] * inverse_cell[2][0],
-            pair.vector[0] * inverse_cell[0][1] + pair.vector[1] * inverse_cell[1][1] + pair.vector[2] * inverse_cell[2][1],
-            pair.vector[0] * inverse_cell[0][2] + pair.vector[1] * inverse_cell[1][2] + pair.vector[2] * inverse_cell[2][2],
-        );
-
+        let mut lm_index = 0;
+        let mut lm_index_grad = 0;
         for spherical_harmonics_l in 0..=self.parameters.max_angular {
-            let first_block_id = descriptor.keys().position(&[
-                spherical_harmonics_l.into(),
-                pair.first_species.into(),
-                pair.second_species.into()
-            ]);
-
-            let second_block_id = if pair.first_sample == pair.second_sample {
-                // do not compute for the reversed pair if the pair is
-                // between an atom and its image
-                None
-            } else {
-                descriptor.keys().position(&[
-                    spherical_harmonics_l.into(),
-                    pair.second_species.into(),
-                    pair.first_species.into()
-                ])
-            };
-
-            if first_block_id.is_none() && second_block_id.is_none() {
-                continue;
-            }
-
             let spherical_harmonics_grad = [
                 spherical_harmonics.gradients[0].slice(spherical_harmonics_l as isize),
                 spherical_harmonics.gradients[1].slice(spherical_harmonics_l as isize),
@@ -315,19 +260,20 @@ impl SphericalExpansion {
             let radial_integral = radial_integral.values.slice(s![spherical_harmonics_l, ..]);
 
             // compute the full spherical expansion coefficients & gradients
-            for (m, sph_value) in spherical_harmonics.iter().enumerate() {
+            for sph_value in spherical_harmonics.iter() {
                 for (n, ri_value) in radial_integral.iter().enumerate() {
                     // The first factor of 4pi arises from the integration over
                     // the angular variables. It is included here as a global
                     // factor since it is not part of the spherical harmonics,
                     // and to keep the radial_integral class about the radial
                     // part of the integration only.
-                    coefficients[[m, n]] = FOUR_PI * f_scaling * sph_value * ri_value;
+                    contribution.values[[lm_index, n]] = FOUR_PI * f_scaling * sph_value * ri_value;
                 }
+                lm_index += 1;
             }
 
-            if let Some(ref mut coefficients_grad) = coefficients_grad {
-                let dr_d_spatial = pair.direction;
+            if let Some(ref mut gradient) = contribution.gradients {
+                let dr_d_spatial = direction;
 
                 for m in 0..(2 * spherical_harmonics_l + 1) {
                     let sph_value = spherical_harmonics[m];
@@ -339,165 +285,278 @@ impl SphericalExpansion {
                         let ri_value = radial_integral[n];
                         let ri_grad = radial_integral_grad[n];
 
-                        coefficients_grad[[0, m, n]] = FOUR_PI * (
+                        gradient[[0, lm_index_grad, n]] = FOUR_PI * (
                             f_scaling_grad * dr_d_spatial[0] * ri_value * sph_value
                             + f_scaling * ri_grad * dr_d_spatial[0] * sph_value
-                            + f_scaling * ri_value * sph_grad_x / pair.distance
+                            + f_scaling * ri_value * sph_grad_x / distance
                         );
 
-                        coefficients_grad[[1, m, n]] = FOUR_PI * (
+                        gradient[[1, lm_index_grad, n]] = FOUR_PI * (
                             f_scaling_grad * dr_d_spatial[1] * ri_value * sph_value
                             + f_scaling * ri_grad * dr_d_spatial[1] * sph_value
-                            + f_scaling * ri_value * sph_grad_y / pair.distance
+                            + f_scaling * ri_value * sph_grad_y / distance
                         );
 
-                        coefficients_grad[[2, m, n]] = FOUR_PI * (
+                        gradient[[2, lm_index_grad, n]] = FOUR_PI * (
                             f_scaling_grad * dr_d_spatial[2] * ri_value * sph_value
                             + f_scaling * ri_grad * dr_d_spatial[2] * sph_value
-                            + f_scaling * ri_value * sph_grad_z / pair.distance
+                            + f_scaling * ri_value * sph_grad_z / distance
                         );
                     }
+
+                    lm_index_grad += 1;
                 }
-            }
-
-            if let Some(block_id) = first_block_id {
-                SphericalExpansion::accumulate_in_block(
-                    descriptor.block_mut_by_id(block_id),
-                    spherical_harmonics_l,
-                    (pair.first_sample, pair.second_sample),
-                    inverse_cell_pair_vector,
-                    &coefficients,
-                    &coefficients_grad,
-                    do_gradients,
-                );
-            }
-
-            if let Some(block_id) = second_block_id {
-                // inverting the pair is equivalent to adding a (-1)^l factor to
-                // the pair contribution values, and -(-1)^l to the gradients
-                coefficients *= self.m_1_pow_l[spherical_harmonics_l];
-                if let Some(ref mut coefficients_grad) = coefficients_grad {
-                    *coefficients_grad *= -self.m_1_pow_l[spherical_harmonics_l];
-                }
-
-                SphericalExpansion::accumulate_in_block(
-                    descriptor.block_mut_by_id(block_id),
-                    spherical_harmonics_l,
-                    (pair.second_sample, pair.first_sample),
-                    -inverse_cell_pair_vector,
-                    &coefficients,
-                    &coefficients_grad,
-                    do_gradients,
-                );
             }
         }
     }
 
-    /// Store the data as required in block, dealing with the user requesting a
-    /// subset of properties/samples
-    fn accumulate_in_block(
-        mut block: TensorBlockRefMut,
-        spherical_harmonics_l: usize,
-        (first_sample, second_sample): ([LabelValue; 2], [LabelValue; 2]),
-        inverse_cell_pair_vector: Vector3D,
-        pair_contribution: &Array2<f64>,
-        pair_contribution_grad: &Option<Array3<f64>>,
-        do_gradient: GradientsOptions,
-    ) {
+    /// For one system, compute the spherical expansion and corresponding
+    /// gradients by summing over the pairs.
+    #[allow(clippy::too_many_lines)]
+    fn accumulate_all_pairs(
+        &self,
+        system: &dyn System,
+        do_gradients: GradientsOptions,
+        requested_centers: &BTreeSet<usize>,
+    ) -> Result<PairAccumulationResult, Error> {
+        // pre-filter pairs to only include the ones containing at least one of
+        // the requested atoms
+        let pairs = system.pairs()?;
 
-        let values = block.values_mut();
-        let mut array = array_mut_for_system(&mut values.data);
+        let pair_should_contribute = |pair: &&crate::systems::Pair| {
+            requested_centers.contains(&pair.first) || requested_centers.contains(&pair.second)
+        };
+        let pairs_count = pairs.iter().filter(pair_should_contribute).count();
 
-        let first_sample_position = values.samples.position(&first_sample);
-        if first_sample_position.is_none() {
-            // nothing to do
-            return;
+        let system_size = system.size()?;
+        let species = system.species()?;
+
+        let mut species_mapping = BTreeMap::new();
+        for &s in species {
+            let next_idx = species_mapping.len();
+            species_mapping.entry(s).or_insert(next_idx);
         }
-        let sample_i = first_sample_position.expect("we just checked");
 
-        for m in 0..(2 * spherical_harmonics_l + 1) {
-            for (property_i, &[n]) in values.properties.iter_fixed_size().enumerate() {
-                // SAFETY: we are doing in-bounds access, and removing
-                // the bounds checks is a significant speed-up for this code
-                unsafe {
-                    let out = array.uget_mut([sample_i, m, property_i]);
-                    *out += *pair_contribution.uget([m, n.usize()]);
-                }
+        let inverse_cell = if do_gradients.cell {
+            let cell = system.cell()?;
+            if cell.shape() == CellShape::Infinite {
+                return Err(Error::InvalidParameter(
+                    "can not compute cell gradients for non periodic systems".into()
+                ));
             }
-        }
+            cell.matrix().inverse()
+        } else {
+            Matrix3::zero()
+        };
 
-        // accumulate gradients w.r.t. positions
-        if do_gradient.positions {
-            let pair_contribution_grad = pair_contribution_grad.as_ref().expect("missing pair contribution to gradients");
-            let gradient = block.gradient_mut("positions").expect("missing gradient storage");
-            let mut array = array_mut_for_system(&mut gradient.data);
+        let centers_mapping = (0..system_size).map(|center_i| {
+            requested_centers.iter().position(|&center| center == center_i)
+        }).collect::<Vec<_>>();
 
-            // gradient of the first sample with respect to the first atom
-            let self_grad_sample_i = gradient.samples.position(&[
-                // first_sample contains [system_i, first_atom]
-                sample_i.into(), first_sample[0], first_sample[1]
-            ]);
+        // total number of joined (l, m) indices
+        let lm_shape = (self.parameters.max_angular + 1) * (self.parameters.max_angular + 1);
+        let mut contribution = PairContribution {
+            values: ndarray::Array2::from_elem((lm_shape, self.parameters.max_radial), 0.0),
+            gradients: if do_gradients.either() {
+                let shape = (3, lm_shape, self.parameters.max_radial);
+                Some(ndarray::Array3::from_elem(shape, 0.0))
+            } else {
+                None
+            }
+        };
 
-            // gradient of the first sample with respect to the second atom
-            let other_grad_sample_i = gradient.samples.position(&[
-                sample_i.into(), second_sample[0], second_sample[1]
-            ]);
+        let max_radial = self.parameters.max_radial;
+        let mut result = PairAccumulationResult {
+            values: ndarray::Array4::from_elem(
+                (species_mapping.len(), requested_centers.len(), lm_shape, max_radial),
+                0.0
+            ),
+            positions_gradients_by_pair: if do_gradients.positions {
+                let shape = (pairs_count, 3, lm_shape, max_radial);
+                Some(ndarray::Array4::from_elem(shape, 0.0))
+            } else {
+                None
+            },
+            positions_gradients_self: if do_gradients.positions {
+                let shape = (species_mapping.len(), requested_centers.len(), 3, lm_shape, max_radial);
+                Some(ndarray::Array5::from_elem(shape, 0.0))
+            } else {
+                None
+            },
+            cell_gradients: if do_gradients.cell {
+                Some(ndarray::Array6::from_elem(
+                    (species_mapping.len(), requested_centers.len(), 3, 3, lm_shape, max_radial),
+                    0.0)
+                )
+            } else {
+                None
+            },
+            species_mapping,
+            centers_mapping,
+            pair_to_pair_ids: HashMap::new(),
+        };
 
-            if let Some(gradient_sample_i) = self_grad_sample_i {
-                for spatial in 0..3 {
-                    for m in 0..(2 * spherical_harmonics_l + 1) {
-                        for (property_i, &[n]) in gradient.properties.iter_fixed_size().enumerate() {
-                            // SAFETY: we are doing in-bounds access, and
-                            // removing the bounds checks is a significant
-                            // speed-up for this code
-                            unsafe {
-                                let out = array.uget_mut([gradient_sample_i, spatial, m, property_i]);
-                                *out -= *pair_contribution_grad.uget([spatial, m, n.usize()]);
+        for (pair_id, pair) in pairs.iter().filter(pair_should_contribute).enumerate() {
+            debug_assert!(requested_centers.contains(&pair.first) || requested_centers.contains(&pair.second));
+
+            let mut direction = pair.vector / pair.distance;
+            // Deal with the possibility that two atoms are at the same
+            // position. While this is not usual, there is no reason to prevent
+            // the calculation of spherical expansion. The user will still get a
+            // warning about atoms being very close together when calculating
+            // the neighbor list.
+            if pair.distance < 1e-6 {
+                direction = Vector3D::new(0.0, 0.0, 1.0);
+            }
+
+            self.compute_for_pair(pair.distance, direction, do_gradients, &mut contribution);
+
+            let inverse_cell_pair_vector = Vector3D::new(
+                pair.vector[0] * inverse_cell[0][0] + pair.vector[1] * inverse_cell[1][0] + pair.vector[2] * inverse_cell[2][0],
+                pair.vector[0] * inverse_cell[0][1] + pair.vector[1] * inverse_cell[1][1] + pair.vector[2] * inverse_cell[2][1],
+                pair.vector[0] * inverse_cell[0][2] + pair.vector[1] * inverse_cell[1][2] + pair.vector[2] * inverse_cell[2][2],
+            );
+
+            if let Some(mapped_center) = result.centers_mapping[pair.first] {
+                // add the pair contribution to the atomic environnement
+                // corresponding to the **first** atom in the pair
+                let neighbor_i = pair.second;
+
+                result.pair_to_pair_ids.entry((pair.first, pair.second))
+                    .or_insert_with(Vec::new)
+                    .push(pair_id);
+
+                let species_neighbor_i = result.species_mapping[&species[neighbor_i]];
+                let mut values = result.values.slice_mut(s![species_neighbor_i, mapped_center, .., ..]);
+                values += &contribution.values;
+
+
+                if let Some(ref contribution_gradients) = contribution.gradients {
+                    if let Some(ref mut positions_gradients) = result.positions_gradients_by_pair {
+                        let gradients = &mut positions_gradients.slice_mut(s![pair_id, .., .., ..]);
+                        gradients.assign(contribution_gradients);
+                    }
+
+                    if let Some(ref mut positions_gradients) = result.positions_gradients_self {
+                        let mut gradients = positions_gradients.slice_mut(s![species_neighbor_i, mapped_center, .., .., ..]);
+                        gradients -= contribution_gradients;
+                    }
+
+                    if let Some(ref mut cell_gradients) = result.cell_gradients {
+                        let mut cell_gradients = cell_gradients.slice_mut(
+                            s![species_neighbor_i, mapped_center, .., .., .., ..]
+                        );
+
+                        for spatial_1 in 0..3 {
+                            for spatial_2 in 0..3 {
+                                let inverse_cell_pair_vector_2 = inverse_cell_pair_vector[spatial_2];
+
+                                let mut lm_index = 0;
+                                for spherical_harmonics_l in 0..=self.parameters.max_angular {
+                                    for _m in 0..(2 * spherical_harmonics_l + 1) {
+                                        for n in 0..self.parameters.max_radial {
+                                            // SAFETY: we are doing in-bounds
+                                            // access, and removing the bounds
+                                            // checks is a significant speed-up
+                                            // for this code. There is also a
+                                            // bounds check when running tests
+                                            // in debug mode.
+                                            unsafe {
+                                                let out = cell_gradients.uget_mut([spatial_1, spatial_2, lm_index, n]);
+                                                *out += inverse_cell_pair_vector_2 * contribution_gradients.uget([spatial_1, lm_index, n]);
+                                            }
+                                        }
+                                        lm_index += 1;
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
 
-            if let Some(gradient_sample_i) = other_grad_sample_i {
-                for spatial in 0..3 {
-                    for m in 0..(2 * spherical_harmonics_l + 1) {
-                        for (property_i, &[n]) in gradient.properties.iter_fixed_size().enumerate() {
-                            // SAFETY: we are doing in-bounds access, and
-                            // removing the bounds checks is a significant
-                            // speed-up for this code
-                            unsafe {
-                                let out = array.uget_mut([gradient_sample_i, spatial, m, property_i]);
-                                *out += *pair_contribution_grad.uget([spatial, m, n.usize()]);
+            if pair.first == pair.second {
+                // do not compute for the reversed pair if the pair is
+                // between an atom and its image
+                continue;
+            }
+
+            if let Some(mapped_center) = result.centers_mapping[pair.second] {
+                // add the pair contribution to the atomic environnement
+                // corresponding to the **second** atom in the pair
+                let neighbor_i = pair.first;
+
+                result.pair_to_pair_ids.entry((pair.second, pair.first))
+                    .or_insert_with(Vec::new)
+                    .push(pair_id);
+
+
+                // inverting the pair is equivalent to adding a (-1)^l
+                // factor to the pair contribution values, and -(-1)^l
+                // to the gradients
+                let mut lm_index = 0;
+                for spherical_harmonics_l in 0..=self.parameters.max_angular {
+                    let factor = self.m_1_pow_l[spherical_harmonics_l];
+                    for _m in 0..(2 * spherical_harmonics_l + 1) {
+                        for n in 0..self.parameters.max_radial {
+                            contribution.values[[lm_index, n]] *= factor;
+                        }
+                        lm_index += 1;
+                    }
+                }
+
+                if let Some(ref mut gradients) = contribution.gradients {
+                    for spatial in 0..3 {
+                        let mut lm_index = 0;
+                        for spherical_harmonics_l in 0..=self.parameters.max_angular {
+                            let factor = -self.m_1_pow_l[spherical_harmonics_l];
+                            for _m in 0..(2 * spherical_harmonics_l + 1) {
+                                for n in 0..self.parameters.max_radial {
+                                    gradients[[spatial, lm_index, n]] *= factor;
+                                }
+                                lm_index += 1;
                             }
                         }
                     }
                 }
-            }
-        }
 
-        // accumulate gradients w.r.t. cell vector
-        if do_gradient.cell {
-            let pair_contribution_grad = pair_contribution_grad.as_ref().expect("missing pair contribution to gradients");
-            let gradient = block.gradient_mut("cell").expect("missing gradient storage");
-            let mut array = array_mut_for_system(&mut gradient.data);
+                let species_neighbor_i = result.species_mapping[&species[neighbor_i]];
 
-            // gradient of the first sample with respect to the first atom
-            let gradient_sample_i = gradient.samples.position(&[sample_i.into()]);
+                let mut values = result.values.slice_mut(s![species_neighbor_i, mapped_center, .., ..]);
+                values += &contribution.values;
 
-            if let Some(gradient_sample_i) = gradient_sample_i {
-                for spatial_1 in 0..3 {
-                    for spatial_2 in 0..3 {
-                        let inverse_cell_pair_vector_2 = inverse_cell_pair_vector[spatial_2];
-                        for m in 0..(2 * spherical_harmonics_l + 1) {
-                            for (property_i, &[n]) in gradient.properties.iter_fixed_size().enumerate() {
-                                // SAFETY: we are doing in-bounds access, and
-                                // removing the bounds checks is a significant
-                                // speed-up for this code
-                                unsafe {
-                                    let out = array.uget_mut([gradient_sample_i, spatial_1, spatial_2, m, property_i]);
-                                    *out += *pair_contribution_grad.uget([spatial_1, m, n.usize()])
-                                            * inverse_cell_pair_vector_2;
+                if let Some(ref contribution_gradients) = contribution.gradients {
+                    // we don't add second->first pair to positions_gradient_by_pair,
+                    // instead handling this in position_gradients_to_equistore
+
+                    if let Some(ref mut positions_gradients) = result.positions_gradients_self {
+                        let mut gradients = positions_gradients.slice_mut(s![species_neighbor_i, mapped_center, .., .., ..]);
+                        gradients -= contribution_gradients;
+                    }
+
+                    if let Some(ref mut cell_gradients) = result.cell_gradients {
+                        let inverse_cell_pair_vector = -inverse_cell_pair_vector;
+
+                        let mut cell_gradients = cell_gradients.slice_mut(
+                            s![species_neighbor_i, mapped_center, .., .., .., ..]
+                        );
+
+                        for spatial_1 in 0..3 {
+                            for spatial_2 in 0..3 {
+                                let inverse_cell_pair_vector_2 = inverse_cell_pair_vector[spatial_2];
+
+                                let mut lm_index = 0;
+                                for spherical_harmonics_l in 0..=self.parameters.max_angular {
+                                    for _m in 0..(2 * spherical_harmonics_l + 1) {
+                                        for n in 0..self.parameters.max_radial {
+                                            // SAFETY: as above
+                                            unsafe {
+                                                let out = cell_gradients.uget_mut([spatial_1, spatial_2, lm_index, n]);
+                                                *out += inverse_cell_pair_vector_2 * contribution_gradients.uget([spatial_1, lm_index, n]);
+                                            }
+                                        }
+                                        lm_index += 1;
+                                    }
                                 }
                             }
                         }
@@ -505,6 +564,241 @@ impl SphericalExpansion {
                 }
             }
         }
+
+        return Ok(result);
+    }
+
+    /// Move the pre-computed spherical expansion data to a single equistore
+    /// block
+    #[allow(clippy::unused_self)]
+    fn values_to_equistore(
+        &self,
+        key: &[LabelValue],
+        block: &mut TensorBlockRefMut,
+        system: &dyn System,
+        data: &PairAccumulationResult,
+    ) -> Result<(), Error> {
+        let species = system.species()?;
+        let system_size = system.size()?;
+
+        let spherical_harmonics_l = key[0].usize();
+        let species_center = key[1];
+        let species_neighbor = key[2];
+
+        let lm_start = spherical_harmonics_l * spherical_harmonics_l;
+        let species_neighbor_i = if let Some(s) = data.species_mapping.get(&species_neighbor.i32()) {
+            *s
+        } else {
+            // this block does not correspond to actual species in the current
+            // system
+            return Ok(());
+        };
+
+        let values = block.values_mut();
+        let mut array = array_mut_for_system(&mut values.data);
+
+        for (sample_i, [_, center_i]) in values.samples.iter_fixed_size().enumerate() {
+            // samples might contain entries for atoms that should not be part
+            // of this block, these entries can be manually requested by users.
+            if center_i.usize() >= system_size || species[center_i.usize()] != species_center {
+                continue;
+            }
+            let mapped_center = data.centers_mapping[center_i.usize()].expect("this center should be part of the mapping");
+
+            for m in 0..(2 * spherical_harmonics_l + 1) {
+                for (property_i, [n]) in values.properties.iter_fixed_size().enumerate() {
+                    // SAFETY: we are doing in-bounds access, and removing the
+                    // bounds checks is a significant speed-up for this code.
+                    // There is also a bounds check when running tests in debug
+                    // mode.
+                    unsafe {
+                        let out = array.uget_mut([sample_i, m, property_i]);
+                        *out += *data.values.uget([species_neighbor_i, mapped_center, lm_start + m, n.usize()]);
+                    }
+                }
+            }
+        }
+
+        return Ok(());
+    }
+
+    /// Finalize the spherical expansion gradients w.r.t. positions from the
+    /// gradients associated with each pair, filling a single equistore block
+    ///
+    /// A single pair between atoms `i-j` will contribute to four gradients
+    /// entries. Two "cross" gradients:
+    ///     - gradient of the spherical expansion of `i` w.r.t. `j`;
+    ///     - gradient of the spherical expansion of `j` w.r.t. `i`;
+    /// and two "self" gradients:
+    ///     - gradient of the spherical expansion of `i` w.r.t. `i`;
+    ///     - gradient of the spherical expansion of `j` w.r.t. `j`;
+    ///
+    /// The self gradients are pre-summed in `accumulate_all_pairs`, while cross
+    /// gradients are directly summed in this function.
+    fn position_gradients_to_equistore(
+        &self,
+        key: &[LabelValue],
+        block: &mut TensorBlockRefMut,
+        system: &dyn System,
+        data: &PairAccumulationResult,
+    ) -> Result<(), Error> {
+        let positions_gradients_by_pair = if let Some(ref data) = data.positions_gradients_by_pair {
+            data
+        } else {
+            // no positions gradients, return early
+            return Ok(());
+        };
+
+        let positions_gradients_self = data.positions_gradients_self.as_ref()
+            .expect("missing self gradients");
+
+        let spherical_harmonics_l = key[0].usize();
+        let species_center = key[1];
+        let species_neighbor = key[2];
+        let species_neighbor_i = if let Some(s) = data.species_mapping.get(&species_neighbor.i32()) {
+            *s
+        } else {
+            // this block does not correspond to actual species in the current
+            // system
+            return Ok(());
+        };
+
+        let species = system.species()?;
+        let pairs = system.pairs()?;
+        let system_size = system.size()?;
+
+        let lm_start = spherical_harmonics_l * spherical_harmonics_l;
+        let m_1_pow_l = self.m_1_pow_l[spherical_harmonics_l];
+
+        let values_samples = Arc::clone(&block.values().samples);
+        let gradient = block.gradient_mut("positions").expect("TODO");
+        let mut array = array_mut_for_system(&mut gradient.data);
+
+        for (grad_sample_i, &[sample_i, _, neighbor_i]) in gradient.samples.iter_fixed_size().enumerate() {
+            let center_i = values_samples[sample_i.usize()][1];
+
+            // gradient samples should NOT contain entries for atoms that should
+            // not be part of this block, since they are not manually specified
+            // by the users
+            debug_assert!(center_i.usize() < system_size && species[center_i.usize()] == species_center);
+
+            if center_i == neighbor_i {
+                // gradient of an environment w.r.t. the position of the center,
+                // we already summed over the contributions from all pairs this
+                // center is part of in `data.positions_gradients_self`
+
+                let mapped_center = data.centers_mapping[center_i.usize()]
+                    .expect("this center should be part of the requested centers");
+
+                for spatial in 0..3 {
+                    for m in 0..(2 * spherical_harmonics_l + 1) {
+                        for (property_i, [n]) in gradient.properties.iter_fixed_size().enumerate() {
+                            // SAFETY: same as above
+                            unsafe {
+                                let out = array.uget_mut([grad_sample_i, spatial, m, property_i]);
+                                *out = *positions_gradients_self.uget(
+                                    [species_neighbor_i, mapped_center, spatial, lm_start + m, n.usize()]
+                                );
+                            }
+                        }
+                    }
+                }
+            } else {
+                // gradient w.r.t. the position of a neighboring atom
+                let neighbor_i = neighbor_i.usize();
+                debug_assert!(species[neighbor_i] == species_neighbor);
+
+                for &pair_id in &data.pair_to_pair_ids[&(center_i.usize(), neighbor_i)] {
+                    let pair = pairs[pair_id];
+                    let factor = if pair.first == center_i.usize() {
+                        debug_assert_eq!(pair.second, neighbor_i);
+                        1.0
+                    } else {
+                        debug_assert!(pair.second == center_i.usize());
+                        debug_assert_eq!(pair.first, neighbor_i);
+                        -m_1_pow_l
+                    };
+
+                    for spatial in 0..3 {
+                        for m in 0..(2 * spherical_harmonics_l + 1) {
+                            for (property_i, [n]) in gradient.properties.iter_fixed_size().enumerate() {
+                                // SAFETY: same as above
+                                unsafe {
+                                    let out = array.uget_mut([grad_sample_i, spatial, m, property_i]);
+                                    *out += factor * *positions_gradients_by_pair.uget([pair_id, spatial, lm_start + m, n.usize()]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(());
+    }
+
+    /// Move the pre-computed spherical expansion gradients w.r.t. cell to
+    /// a single equistore block
+    #[allow(clippy::unused_self)]
+    fn cell_gradients_to_equistore(
+        &self,
+        key: &[LabelValue],
+        block: &mut TensorBlockRefMut,
+        system: &dyn System,
+        data: &PairAccumulationResult,
+    ) -> Result<(), Error> {
+        let contributions = if let Some(ref data) = data.cell_gradients {
+            data
+        } else {
+            // no cell gradients, return early
+            return Ok(());
+        };
+
+        let species = system.species()?;
+        let system_size = system.size()?;
+
+        let spherical_harmonics_l = key[0].usize();
+        let species_center = key[1];
+        let species_neighbor = key[2];
+
+        let lm_start = spherical_harmonics_l * spherical_harmonics_l;
+        let species_neighbor_i = if let Some(s) = data.species_mapping.get(&species_neighbor.i32()) {
+            *s
+        } else {
+            // this block does not correspond to actual species in the current
+            // system
+            return Ok(());
+        };
+
+        let values_samples = Arc::clone(&block.values().samples);
+        let gradient = block.gradient_mut("cell").expect("TODO");
+        let mut array = array_mut_for_system(&mut gradient.data);
+
+        for (grad_sample_i, [sample_i]) in gradient.samples.iter_fixed_size().enumerate() {
+            let center_i = values_samples[sample_i.usize()][1];
+
+            // gradient samples should NOT contain entries for atoms that should
+            // not be part of this block, since they are not manually specified
+            // by the users
+            debug_assert!(center_i.usize() < system_size && species[center_i.usize()] == species_center);
+            let mapped_center = data.centers_mapping[center_i.usize()].expect("this center should be part of the mapping");
+
+            for spatial_1 in 0..3 {
+                for spatial_2 in 0..3 {
+                    for m in 0..(2 * spherical_harmonics_l + 1) {
+                        for (property_i, [n]) in gradient.properties.iter_fixed_size().enumerate() {
+                            // SAFETY: same as above
+                            unsafe {
+                                let out = array.uget_mut([grad_sample_i, spatial_1, spatial_2, m, property_i]);
+                                *out += *contributions.uget([species_neighbor_i, mapped_center, spatial_1, spatial_2, lm_start + m, n.usize()]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(());
     }
 }
 
@@ -521,6 +815,48 @@ impl GradientsOptions {
     }
 }
 
+
+/// Contribution of a single pair to the spherical expansion
+struct PairContribution {
+    values: ndarray::Array2<f64>,
+    gradients: Option<ndarray::Array3<f64>>,
+}
+
+/// Result of `accumulate_all_pairs`, summing over all pairs in a system
+struct PairAccumulationResult {
+    /// values of the spherical expansion
+    ///
+    /// the shape is [species_neighbor, mapped_center, lm_index, n]
+    values: ndarray::Array4<f64>,
+    /// gradients w.r.t. positions associated with each pair used in the
+    /// calculation. This is used for gradients of a given center representation
+    /// with respect to one of the neighbors
+    ///
+    /// the shape is [pair_id, spatial, lm_index, n]
+    positions_gradients_by_pair: Option<ndarray::Array4<f64>>,
+    /// gradient of spherical expansion w.r.t. the position of the central atom
+    ///
+    /// this is separate from `positions_gradients_by_pair` because it can be
+    /// summed while computing each pair contributions.
+    ///
+    /// the shape is [species_neighbor, mapped_center, spatial, lm_index, n]
+    positions_gradients_self: Option<ndarray::Array5<f64>>,
+    /// gradients of the spherical expansion w.r.t. cell
+    ///
+    /// the shape is [species_neighbor, mapped_center, spatial_1, spatial_2, lm_index, n]
+    cell_gradients: Option<ndarray::Array6<f64>>,
+
+    /// Mapping from the species to the first dimension of values/cell_gradients
+    species_mapping: BTreeMap<i32, usize>,
+    /// Mapping from the atomic index to the second dimension of values/cell_gradients
+    centers_mapping: Vec<Option<usize>>,
+    /// Mapping from couples of atoms to (potentially multiple) pair_id (first
+    /// dimension of positions_gradients_by_pair).
+    ///
+    /// Two atoms can have more than one pair between them, so we need to be
+    /// able store more than one pair id.
+    pair_to_pair_ids: HashMap<(usize, usize), Vec<usize>>,
+}
 
 impl CalculatorBase for SphericalExpansion {
     fn name(&self) -> String {
@@ -599,6 +935,8 @@ impl CalculatorBase for SphericalExpansion {
 
         let mut gradient_samples = Vec::new();
         for ([_, species_center, species_neighbor], samples) in keys.iter_fixed_size().zip(samples) {
+            // TODO: we don't need to rebuild the gradient samples for different
+            // spherical_harmonics_l
             let builder = AtomCenteredSamples {
                 cutoff: self.parameters.cutoff,
                 species_center: SpeciesFilter::Single(species_center.i32()),
@@ -667,54 +1005,28 @@ impl CalculatorBase for SphericalExpansion {
 
         systems.par_iter_mut()
             .zip_eq(&mut descriptors_by_system)
-            .enumerate()
-            .try_for_each(|(system_i, (system, descriptor))| {
+            .try_for_each(|(system, descriptor)| {
                 system.compute_neighbors(self.parameters.cutoff)?;
-                let species = system.species()?;
-                let pairs = system.pairs()?;
+                let system = &**system;
 
-                let inverse_cell = if do_gradients.cell {
-                    let cell = system.cell()?;
-                    if cell.shape() == CellShape::Infinite {
-                        return Err(Error::InvalidParameter(
-                            "can not compute cell gradients for non periodic systems".into()
-                        ));
-                    }
-                    cell.matrix().inverse()
-                } else {
-                    Matrix3::zero()
-                };
-
+                // we will only run the calculation on pairs where one of the
+                // atom is part of the requested samples
                 let requested_centers = descriptor.iter().flat_map(|(_, block)| {
                     block.values().samples.iter().map(|sample| sample[1].usize())
                 }).collect::<BTreeSet<_>>();
 
-                for pair in pairs {
-                    if !requested_centers.contains(&pair.first) && !requested_centers.contains(&pair.second) {
-                        continue;
-                    }
+                let accumulated = self.accumulate_all_pairs(
+                    system,
+                    do_gradients,
+                    &requested_centers,
+                )?;
 
-                    let mut direction = pair.vector / pair.distance;
-                    // Deal with the possibility that two atoms are at the same
-                    // position. While this is not usual, there is no reason to
-                    // prevent the calculation of spherical expansion. The user will
-                    // still get a warning about atoms being very close together
-                    // when calculating the neighbor list.
-                    if pair.distance < 1e-6 {
-                        direction = Vector3D::new(0.0, 0.0, 1.0);
-                    }
-
-                    let pair = Pair {
-                        first_sample: [system_i.into(), pair.first.into()],
-                        second_sample: [system_i.into(), pair.second.into()],
-                        first_species: species[pair.first],
-                        second_species: species[pair.second],
-                        distance: pair.distance,
-                        direction: direction,
-                        vector: pair.vector,
-                    };
-
-                    self.compute_for_pair(&pair, descriptor, do_gradients, &inverse_cell);
+                // all pairs are done, copy the data into equistore, handling
+                // any property selection made by the user
+                for (key, mut block) in descriptor.iter_mut() {
+                    self.values_to_equistore(key, &mut block, system, &accumulated)?;
+                    self.position_gradients_to_equistore(key, &mut block, system, &accumulated)?;
+                    self.cell_gradients_to_equistore(key, &mut block, system, &accumulated)?;
                 }
 
                 Ok::<_, Error>(())

--- a/rascaline/src/lib.rs
+++ b/rascaline/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::unreadable_literal, clippy::option_if_let_else, clippy::range_plus_one)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::module_name_repetitions)]
 #![allow(clippy::manual_assert, clippy::return_self_not_must_use, clippy::match_like_matches_macro)]
-#![allow(clippy::needless_range_loop)]
+#![allow(clippy::needless_range_loop, clippy::uninlined_format_args)]
 
 #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_wrap, clippy::cast_lossless, clippy::cast_sign_loss)]

--- a/rascaline/src/systems/neighbors.rs
+++ b/rascaline/src/systems/neighbors.rs
@@ -4,30 +4,6 @@ use ndarray::Array3;
 use crate::{Matrix3, Vector3D};
 use super::{UnitCell, Pair};
 
-/// `f64::clamp` backported to rust 1.45
-fn f64_clamp(mut x: f64, min: f64, max: f64) -> f64 {
-    debug_assert!(min <= max);
-    if x < min {
-        x = min;
-    }
-    if x > max {
-        x = max;
-    }
-    return x;
-}
-
-/// `usize::clamp` backported to rust 1.45
-fn usize_clamp(mut x: usize, min: usize, max: usize) -> usize {
-    debug_assert!(min <= max);
-    if x < min {
-        x = min;
-    }
-    if x > max {
-        x = max;
-    }
-    return x;
-}
-
 /// Maximal number of cells, we need to use this to prevent having too many
 /// cells with a small unit cell and a large cutoff
 const MAX_NUMBER_OF_CELLS: f64 = 1e5;
@@ -132,9 +108,9 @@ impl CellList {
         };
 
         let mut n_cells = [
-            f64_clamp(f64::trunc(distances_between_faces[0] / cutoff), 1.0, f64::INFINITY),
-            f64_clamp(f64::trunc(distances_between_faces[1] / cutoff), 1.0, f64::INFINITY),
-            f64_clamp(f64::trunc(distances_between_faces[2] / cutoff), 1.0, f64::INFINITY),
+            f64::clamp(f64::trunc(distances_between_faces[0] / cutoff), 1.0, f64::INFINITY),
+            f64::clamp(f64::trunc(distances_between_faces[1] / cutoff), 1.0, f64::INFINITY),
+            f64::clamp(f64::trunc(distances_between_faces[2] / cutoff), 1.0, f64::INFINITY),
         ];
 
         assert!(n_cells[0].is_finite() && n_cells[1].is_finite() && n_cells[2].is_finite());
@@ -209,9 +185,9 @@ impl CellList {
         // cell
         let (shift, cell_index) = if self.unit_cell.is_infinite() {
             let cell_index = [
-                usize_clamp(cell_index[0] as usize, 0, n_cells[0] - 1),
-                usize_clamp(cell_index[1] as usize, 0, n_cells[1] - 1),
-                usize_clamp(cell_index[2] as usize, 0, n_cells[2] - 1),
+                usize::clamp(cell_index[0] as usize, 0, n_cells[0] - 1),
+                usize::clamp(cell_index[1] as usize, 0, n_cells[1] - 1),
+                usize::clamp(cell_index[2] as usize, 0, n_cells[2] - 1),
             ];
             ([0, 0, 0], cell_index)
         } else {

--- a/rascaline/tests/data/mod.rs
+++ b/rascaline/tests/data/mod.rs
@@ -12,7 +12,7 @@ use rascaline::systems::UnitCell;
 type HyperParameters = String;
 
 pub fn load_calculator_input(path: impl AsRef<Path>) -> (Vec<Box<dyn System>>, HyperParameters) {
-    let json = std::fs::read_to_string(&format!("tests/data/generated/{}", path.as_ref().display()))
+    let json = std::fs::read_to_string(format!("tests/data/generated/{}", path.as_ref().display()))
         .expect("failed to read input file");
 
     let data: Value = serde_json::from_str(&json).expect("failed to parse JSON");
@@ -60,7 +60,7 @@ fn read_cell(cell: &Value) -> UnitCell {
 }
 
 pub fn load_expected_values(path: impl AsRef<Path>) -> ArrayD<f64> {
-    let file = std::fs::File::open(&format!("tests/data/generated/{}", path.as_ref().display()))
+    let file = std::fs::File::open(format!("tests/data/generated/{}", path.as_ref().display()))
         .expect("failed to open file");
 
     ArrayD::<f64>::read_npy(GzDecoder::new(file)).expect("failed to convert data to ndarray")

--- a/rascaline/tests/lode-madelung.rs
+++ b/rascaline/tests/lode-madelung.rs
@@ -81,8 +81,8 @@ fn madelung() {
         CrystalParameters{systems: get_znso4(), charges: vec![1.0, -1.0, 1.0, -1.0], madelung: 1.6413 / f64::sqrt(3. / 8.)}
     ];
 
-    for cutoff in [0.01, 0.027, 0.074, 0.2] {
-        let factor = -1.0 / (4.0 * std::f64::consts::PI * (cutoff as f64).powf(2.0)).powf(0.75);
+    for cutoff in [0.01_f64, 0.027, 0.074, 0.2] {
+        let factor = -1.0 / (4.0 * std::f64::consts::PI * cutoff.powf(2.0)).powf(0.75);
         for atomic_gaussian_width in [0.2, 0.1] {
 
             for crystal in crystals.iter_mut() {
@@ -127,8 +127,8 @@ fn madelung_high_accuracy() {
         CrystalParameters{systems: get_znso4(),  charges: vec![1.0, -1.0, 1.0, -1.0], madelung: 1.6413 / f64::sqrt(3. / 8.)}
     ];
 
-    let cutoff = 0.01;
-    let factor = -1.0 / (4.0 * std::f64::consts::PI * (cutoff as f64).powf(2.0)).powf(0.75);
+    let cutoff = 0.01_f64;
+    let factor = -1.0 / (4.0 * std::f64::consts::PI * cutoff.powf(2.0)).powf(0.75);
 
     for crystal in crystals.iter_mut() {
         let lode_parameters = LodeSphericalExpansionParameters {


### PR DESCRIPTION
Previously, we where looking up block/sample/property for each pair and directly storing pair contributions into equistore. This lookup and accumulation was taking 4x longer than the calculation of pair contribution to the spherical expansion.

The new code accumulates data for all pairs first into temporary arrays, and later moves the data to equistore, making the spherical expansion up to 60% faster without gradients and 15% faster with gradients; while increasing the max RSS requirements by around 35%.

This was discovered while porting rascaline to use https://github.com/lab-cosmo/equistore/pull/85. I'll check that it does improve the results there as well before merging this PR!

## benchmarks results

<details>


```
group                                                                          fewer-equistore-in-spx    master
-----                                                                          ----------------------    ------
SOAP PS(per atom) with gradients/Bulk Silicon/n_max = 15, l_max = 14           1.00    720.2±4.79µs      1.11    800.6±8.17µs
SOAP PS(per atom) with gradients/Bulk Silicon/n_max = 2, l_max = 1             1.00     15.2±0.23µs      1.00     15.2±0.75µs
SOAP PS(per atom) with gradients/Bulk Silicon/n_max = 8, l_max = 7             1.00    104.9±0.46µs      1.04    109.5±0.66µs
SOAP PS(per atom) with gradients/Molecular crystals/n_max = 15, l_max = 14     1.00      2.2±0.06ms      1.05      2.3±0.03ms
SOAP PS(per atom) with gradients/Molecular crystals/n_max = 2, l_max = 1       1.00     39.7±0.53µs      1.01     40.3±0.36µs
SOAP PS(per atom) with gradients/Molecular crystals/n_max = 8, l_max = 7       1.00    277.8±4.47µs      1.02    284.7±6.89µs
SOAP PS(per atom)/Bulk Silicon/n_max = 15, l_max = 14                          1.00     44.2±0.64µs      1.42     62.6±1.39µs
SOAP PS(per atom)/Bulk Silicon/n_max = 2, l_max = 1                            1.00  1951.1±62.96ns      1.09      2.1±0.02µs
SOAP PS(per atom)/Bulk Silicon/n_max = 8, l_max = 7                            1.00      6.8±0.09µs      1.37      9.2±0.06µs
SOAP PS(per atom)/Molecular crystals/n_max = 15, l_max = 14                    1.00    134.4±4.91µs      1.24    166.9±4.07µs
SOAP PS(per atom)/Molecular crystals/n_max = 2, l_max = 1                      1.00      9.5±0.13µs      1.04      9.9±0.11µs
SOAP PS(per atom)/Molecular crystals/n_max = 8, l_max = 7                      1.00     28.3±0.21µs      1.18     33.5±0.37µs
SOAP SPX(per atom) with gradients/Bulk Silicon/n_max = 15, l_max = 14          1.00   539.9±10.25µs      1.12    605.9±5.31µs
SOAP SPX(per atom) with gradients/Bulk Silicon/n_max = 2, l_max = 1            1.00     11.1±0.63µs      1.03     11.4±0.39µs
SOAP SPX(per atom) with gradients/Bulk Silicon/n_max = 8, l_max = 7            1.00     77.8±0.38µs      1.07     83.4±0.40µs
SOAP SPX(per atom) with gradients/Molecular crystals/n_max = 15, l_max = 14    1.00   816.8±28.10µs      1.15    935.6±6.55µs
SOAP SPX(per atom) with gradients/Molecular crystals/n_max = 2, l_max = 1      1.00     14.7±0.21µs      1.09     16.0±0.25µs
SOAP SPX(per atom) with gradients/Molecular crystals/n_max = 8, l_max = 7      1.00    107.5±1.81µs      1.08    116.2±2.82µs
SOAP SPX(per atom)/Bulk Silicon/n_max = 15, l_max = 14                         1.00     32.7±0.50µs      1.68     55.0±1.62µs
SOAP SPX(per atom)/Bulk Silicon/n_max = 2, l_max = 1                           1.00  1448.2±33.84ns      1.10  1589.8±20.90ns
SOAP SPX(per atom)/Bulk Silicon/n_max = 8, l_max = 7                           1.00      7.2±0.04µs      1.19      8.6±0.16µs
SOAP SPX(per atom)/Molecular crystals/n_max = 15, l_max = 14                   1.00     51.0±1.60µs      1.63     83.0±5.17µs
SOAP SPX(per atom)/Molecular crystals/n_max = 2, l_max = 1                     1.00      4.2±0.04µs      1.09      4.6±0.06µs
SOAP SPX(per atom)/Molecular crystals/n_max = 8, l_max = 7                     1.00     11.1±0.12µs      1.46     16.2±0.30µs
```

</details>