### PR TITLE
Add BSD-3 LICENSE file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,16 +113,17 @@ jobs:
     name: check examples / benchmarks / Python build
     strategy:
       matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
 
-      - name: setup Python
+      - name: set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+Guillaume Fraux
+Philip Loche
+Sergei Kliavinek
+Kevin Kazuki Huguenin-Dumittan
+Davide Tisi
+Alexander Goscinski

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Guillaume Fraux
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Guillaume Fraux
+Copyright (c) 2023, rascaline developers
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,8 @@ recursive-include rascaline-c-api *
 recursive-include docs/rascaline-json-schema *
 include Cargo.*
 include pyproject.toml
+include AUTHORS
+include LICENSE
 
 prune python/tests
 prune python/*.egg-info

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -14,8 +14,8 @@ sys.path.append(os.path.join(ROOT, "docs", "extensions"))
 # -- Project information -----------------------------------------------------
 
 project = "Rascaline"
-copyright = f"{datetime.now().date().year}, Rascaline developers"
-author = "Rascaline developers"
+author = ", ".join(open(os.path.join(ROOT, "AUTHORS")).read().splitlines())
+copyright = f"{datetime.now().date().year}, {author}"
 
 
 def load_version_from_cargo_toml():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,40 @@
 [metadata]
 name = rascaline
+url = https://github.com/Luthaf/rascaline
+description = Computing representations for atomistic machine learning
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-
-; license_files =
-; author =
-; author_email =
-; description =
-; keywords =
-; url =
-; classifiers =
-
-python_requires = >=3.7
+keywords = computational science, machine learning, atomistic representations
+license = BSD-3-Clause
+license_files = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: POSIX
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: C
+    Programming Language :: Rust
+    Topic :: Scientific/Engineering,
+    Topic :: Scientific/Engineering :: Bio-Informatics
+    Topic :: Scientific/Engineering :: Chemistry
+    Topic :: Scientific/Engineering :: Physics
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
 packages = find:
+python_requires = >=3.6
 package_dir =
     = python
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ def get_version():
 
 setup(
     version=get_version(),
+    author=", ".join(open(os.path.join(ROOT, "AUTHORS")).read().splitlines()),
     ext_modules=[
         # only declare the extension, it is built & copied as required by cmake
         # in the build_ext command


### PR DESCRIPTION
As the other projects of our ecosystem (chemiscope, chemfiles, equistore, equisolve) rascaline should also use the BSD-3 license. This PRs adds the corresponding LICENSE file.