### PR TITLE
Use glibc==2.28, rust==1.59, update GH actions and use py3.10 in CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,16 +39,16 @@ jobs:
           default: true
           target: ${{ matrix.rust-target }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: build wheel
         env:
           RUST_BUILD_TARGET: ${{ matrix.rust-target }}
         run: |
           pip install wheel
           python setup.py bdist_wheel --plat-name ${{ matrix.platform-name }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -68,15 +68,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: build manylinux2010 with rust docker image
-        run: docker build -t manylinux2010-with-rust python/scripts/build-wheels
+      - name: build manylinux with rust docker image
+        run: docker build -t manylinux-with-rust python/scripts/build-wheels
       - name: build wheel in docker
-        run: docker run --rm -v $(pwd):/code manylinux2010-with-rust bash -c "cd /code && /opt/python/cp38-cp38/bin/python setup.py bdist_wheel"
+        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "cd /code && /opt/python/cp38-cp38/bin/python setup.py bdist_wheel"
       - name: run auditwheel in docker
-        run: docker run --rm -v $(pwd):/code manylinux2010-with-rust bash -c "auditwheel repair /code/dist/*.whl -w /code/dist"
+        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "auditwheel repair /code/dist/*.whl -w /code/dist"
       - name: remove wheel with wrong tag
         run: sudo rm dist/*linux_x86_64.whl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -96,14 +96,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: build sdist
         run: |
           pip install wheel
           python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.tar.gz

--- a/.github/workflows/comment-wheels-pr.yml
+++ b/.github/workflows/comment-wheels-pr.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v6
         with:
           script: |
             async function insertUpdateComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: install dependencies
@@ -51,7 +51,7 @@ jobs:
 
       - name: post link to RTD
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             async function insertUpdateComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
             cargo-build-flags: --release
             do-valgrind: true
           - os: ubuntu-20.04
-            rust-version: 1.56
+            rust-version: 1.59
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
           - os: ubuntu-20.04
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: "!matrix.container"
         with:
           python-version: "3.10"
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - cmake
   tools:
-    python: "3.8"
+    python: "3.10"
     rust: "1.61"
 
 # Build documentation in the docs/ directory with Sphinx

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,7 +57,7 @@ on rascaline:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.56.0 to build rascaline.
+  1.59 to build rascaline.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.6.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/python/rascaline/splines.py
+++ b/python/rascaline/splines.py
@@ -13,7 +13,6 @@ def generate_splines(
     n_spline_points=None,
     requested_accuracy=1e-8,
 ):
-
     """Spline generator for tabulated radial integrals.
 
     Besides some self-explanatory parameters, this function takes as inputs two
@@ -100,7 +99,6 @@ class DynamicSpliner:
         derivatives_fn,
         requested_accuracy,
     ) -> None:
-
         """Dynamic spline generator.
 
         This class can be used to spline any set of functions defined within
@@ -134,7 +132,6 @@ class DynamicSpliner:
             )
 
     def spline(self):
-
         """Calculates and outputs the splines.
 
         The outputs of this function are, respectively:
@@ -206,7 +203,6 @@ class DynamicSpliner:
         return spline_x, spline_f, spline_df
 
     def _compute_from_spline(self, positions):
-
         interpolated_values = []
         for x in positions:
             delta_x = self.spline_points[1].position - self.spline_points[0].position

--- a/python/rascaline/systems/ase.py
+++ b/python/rascaline/systems/ase.py
@@ -89,7 +89,7 @@ class AseSystem(SystemBase):
         self._pairs = []
 
         nl_result = neighborlist.neighbor_list("ijdD", self._atoms, cutoff)
-        for (i, j, d, D) in zip(*nl_result):
+        for i, j, d, D in zip(*nl_result):
             if j < i:
                 # we want a half neighbor list, so drop all duplicated
                 # neighbors
@@ -100,7 +100,7 @@ class AseSystem(SystemBase):
         for _ in range(self.size()):
             self._pairs_by_center.append([])
 
-        for (i, j, d, D) in self._pairs:
+        for i, j, d, D in self._pairs:
             self._pairs_by_center[i].append((i, j, d, D))
             self._pairs_by_center[j].append((i, j, d, D))
 

--- a/python/scripts/build-wheels/Dockerfile
+++ b/python/scripts/build-wheels/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+# Use a many linux with a specification
+# manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_${ARCH}
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
 RUN yum install git -y
 RUN git config --global --add safe.directory /code

--- a/python/tests/splines.py
+++ b/python/tests/splines.py
@@ -16,7 +16,6 @@ def cosine(n, ell, r):
 
 class TestSplines(unittest.TestCase):
     def test_splines_with_n_spline_points(self):
-
         cutoff_radius = 8.0
 
         spline_points = rascaline.generate_splines(

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -18,7 +18,7 @@ serialization = ["equistore/serialization"]
 
 [dependencies]
 rascaline = {path = "../rascaline", version = "0.1.0", default-features = false}
-equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "5b7bb33"}
+equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "467baf0"}
 
 ndarray = "0.15"
 log = { version = "0.4", features = ["std"] }
@@ -29,7 +29,7 @@ libc = "0.2"
 [build-dependencies]
 cbindgen = { version = "0.24", default-features = false }
 glob = "0.3"
-equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "5b7bb33"}
+equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "467baf0"}
 
 [dev-dependencies]
 which = "4"

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -31,7 +31,7 @@ name = "soap-power-spectrum"
 harness = false
 
 [dependencies]
-equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "5b7bb33", features = ["ndarray", "rayon"]}
+equistore = {git = "https://github.com/lab-cosmo/equistore", rev = "467baf0", features = ["ndarray", "rayon"]}
 
 ndarray = {version = "0.15", features = ["approx-0_5", "rayon", "serde"]}
 num-traits = "0.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     = python
 install_requires =
     numpy
-    equistore @ https://github.com/lab-cosmo/equistore/archive/5b7bb33.zip
+    equistore @ https://github.com/lab-cosmo/equistore/archive/467baf0.zip
 
 [options.packages.find]
 where = python

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv =
 
 deps =
     numpy
-    equistore @ https://github.com/lab-cosmo/equistore/archive/5b7bb33.zip
+    equistore @ https://github.com/lab-cosmo/equistore/archive/467baf0.zip
     discover
 
 extra_deps =


### PR DESCRIPTION
As written in the title this updates the CI scripts to ensure them to work properly. To ensure this we have to bump the versions of glibc and rust.