### PR TITLE
Please B028 linter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
             cargo-build-flags: --release
             do-valgrind: true
           - os: ubuntu-20.04
-            rust-version: 1.59
+            rust-version: 1.61
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
           - os: ubuntu-20.04

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,7 +57,7 @@ on rascaline:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.59 to build rascaline.
+  1.61 to build rascaline.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.6.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/docs/rascaline-json-schema/Cargo.toml
+++ b/docs/rascaline-json-schema/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2018"
 publish = false
+rust-version = "1.61"
 
 [[bin]]
 name = "rascaline-json-schema"

--- a/python/rascaline/log.py
+++ b/python/rascaline/log.py
@@ -58,7 +58,11 @@ def _set_logging_callback_impl(library, function):
         try:
             function(log_level, message.decode("utf8"))
         except Exception as e:
-            warnings.warn(f"exception raised in logging callback: {e}", ResourceWarning)
+            warnings.warn(
+                msg=f"exception raised in logging callback: {e}",
+                category=ResourceWarning,
+                stacklevel=1,
+            )
 
     # store the current callback in a global python variable to prevent it from
     # being garbage-collected.

--- a/python/rascaline/log.py
+++ b/python/rascaline/log.py
@@ -59,7 +59,7 @@ def _set_logging_callback_impl(library, function):
             function(log_level, message.decode("utf8"))
         except Exception as e:
             warnings.warn(
-                msg=f"exception raised in logging callback: {e}",
+                message=f"exception raised in logging callback: {e}",
                 category=ResourceWarning,
                 stacklevel=1,
             )

--- a/python/rascaline/systems/ase.py
+++ b/python/rascaline/systems/ase.py
@@ -56,7 +56,8 @@ class AseSystem(SystemBase):
             if np.all(np.bitwise_not(atoms_pbc)):
                 warnings.warn(
                     "periodic boundary conditions are disabled, but the cell "
-                    "matrix is not zero, we will set the cell to zero."
+                    "matrix is not zero, we will set the cell to zero.",
+                    stacklevel=1,
                 )
                 self._cell[:, :] = 0.0
             else:

--- a/python/rascaline/systems/chemfiles.py
+++ b/python/rascaline/systems/chemfiles.py
@@ -11,8 +11,10 @@ try:
 
     if not chemfiles.__version__.startswith("0.10"):
         warnings.warn(
-            "found chemfiles, but the version is not supported: "
-            "we need chemfiles v0.10."
+            mgs="found chemfiles, but the version is not supported: "
+            "we need chemfiles v0.10.",
+            category=ImportWarning,
+            stacklevel=1,
         )
         HAVE_CHEMFILES = False
     else:

--- a/python/rascaline/systems/chemfiles.py
+++ b/python/rascaline/systems/chemfiles.py
@@ -11,7 +11,7 @@ try:
 
     if not chemfiles.__version__.startswith("0.10"):
         warnings.warn(
-            mgs="found chemfiles, but the version is not supported: "
+            message="found chemfiles, but the version is not supported: "
             "we need chemfiles v0.10.",
             category=ImportWarning,
             stacklevel=1,

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "rascaline-c-api"
 version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2021"
+rust-version = "1.61"
 
 [lib]
 name = "rascaline"
@@ -25,7 +26,6 @@ log = { version = "0.4", features = ["std"] }
 once_cell = "1"
 time-graph = {version = "0.1.3", features = ["table", "json"]}
 libc = "0.2"
-
 
 [build-dependencies]
 cbindgen = { version = "0.24", default-features = false }

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = "1"
 time-graph = {version = "0.1.3", features = ["table", "json"]}
 libc = "0.2"
 
+
 [build-dependencies]
 cbindgen = { version = "0.24", default-features = false }
 glob = "0.3"

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -3,6 +3,7 @@ name = "rascaline"
 version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2021"
+rust-version = "1.61"
 
 [lib]
 bench = false
@@ -62,8 +63,3 @@ glob = "0.3"
 ndarray-npy = "0.8"
 flate2 = "1.0.20"
 time-graph = {version = "0.1.3", features = ["table", "json"]}
-
-[patch.crates-io]
-# pin implicit dependency of csv (from criterion) to 1.1.6. Newer versions
-# require at least rustc 1.60 but we still support rustc 1.59.
-csv = "1.1.6"

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -62,3 +62,8 @@ glob = "0.3"
 ndarray-npy = "0.8"
 flate2 = "1.0.20"
 time-graph = {version = "0.1.3", features = ["table", "json"]}
+
+[patch.crates-io]
+# pin implicit dependency of csv (from criterion) to 1.1.6. Newer versions
+# require at least rustc 1.60 but we still support rustc 1.59.
+csv = "1.1.6"


### PR DESCRIPTION
This PR explicitly sets the `stacklevel` of warnings since this is required by [flake8](https://github.com/PyCQA/flake8-bugbear):

> B028: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.

Here, I set the level to `stacklevel=1` (the default) meaning that no additional backtrace information is given. I think we do not need more information for the user because the warnings are well written and a link and codeblock does not help much. If you disagree we can also set it to `2` or `3`.