### PR TITLE
Move the job posting RTD link to a separate workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,9 +48,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages/
           force_orphan: true
-
-      - if: github.event_name == 'pull_request'
-        name: Post link to RTD
-        uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "rascaline"

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,17 @@
+name: readthedocs/actions
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: rascaline


### PR DESCRIPTION
This is porting https://github.com/lab-cosmo/equistore/pull/167 to rascaline