### PR TITLE
Do not include equistore in python wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -73,7 +73,7 @@ jobs:
       - name: build wheel in docker
         run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "cd /code && /opt/python/cp38-cp38/bin/python setup.py bdist_wheel"
       - name: run auditwheel in docker
-        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "auditwheel repair /code/dist/*.whl -w /code/dist"
+        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "auditwheel repair --exclude libequistore.so /code/dist/*.whl -w /code/dist"
       - name: remove wheel with wrong tag
         run: sudo rm dist/*linux_x86_64.whl
       - uses: actions/upload-artifact@v3

--- a/python/scripts/build-wheels/Dockerfile
+++ b/python/scripts/build-wheels/Dockerfile
@@ -1,6 +1,9 @@
 # Use manylinux docker image as a base
 FROM quay.io/pypa/manylinux2010_x86_64
 
+# We need a more recent audiwheel
+RUN /opt/_internal/pipx/venvs/auditwheel/bin/python -m pip install --upgrade auditwheel
+
 RUN yum install git -y
 RUN git config --global --add safe.directory /code
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import subprocess
 
@@ -80,6 +81,13 @@ class cmake_ext(build_ext):
             ["cmake", "--build", build_dir, "--target", "install"],
             check=True,
         )
+
+        # do not include equistore libraries/headers with rascaline wheel
+        for file in glob.glob(os.path.join(install_dir, "lib", "*equistore*")):
+            os.unlink(file)
+
+        for file in glob.glob(os.path.join(install_dir, "include", "equistore*")):
+            os.unlink(file)
 
 
 def get_version():


### PR DESCRIPTION
We are always using libequistore.so from the corresponding Python package, and I just learned about the `--exclude` flag to `auditwheel repair`, which is intended for this exact use case.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--170.org.readthedocs.build/en/170/

<!-- readthedocs-preview rascaline end -->