### PR TITLE
Improve usage of C library from installed Python package

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ breathe >=4.33  # C and C++ => sphinx through doxygen
 sphinx-gallery  # convert python files into nice documentation
 sphinx-tabs     # tabs for code examples (one tab per language)
 pygments >=2.11 # syntax highligthing
-toml            #
+toml            # to extract version number out of Cargo.toml
 myst-parser     # markdown => rst translation, used in extensions/rascaline_json_schema
 
 # dependencies for the tutorials

--- a/python/rascaline/__init__.py
+++ b/python/rascaline/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from pkg_resources import DistributionNotFound, get_distribution

--- a/python/rascaline/_c_api.py
+++ b/python/rascaline/_c_api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''Automatically-generated file, do not edit!!!'''
 # flake8: noqa
 

--- a/python/rascaline/_c_lib.py
+++ b/python/rascaline/_c_lib.py
@@ -10,9 +10,6 @@ from .log import _set_logging_callback_impl, default_logging_callback
 
 _HERE = os.path.realpath(os.path.dirname(__file__))
 
-# path that can be used with cmake to access the rascaline library and headers
-cmake_prefix_path = os.path.join(_HERE, "lib", "cmake")
-
 
 class RascalFinder(object):
     def __init__(self):

--- a/python/rascaline/_c_lib.py
+++ b/python/rascaline/_c_lib.py
@@ -1,4 +1,3 @@
-# -* coding: utf-8 -*
 import os
 import sys
 from ctypes import cdll

--- a/python/rascaline/calculators.py
+++ b/python/rascaline/calculators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 import json
 from typing import List, Optional, Union

--- a/python/rascaline/profiling.py
+++ b/python/rascaline/profiling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ._c_lib import _get_library
 from .utils import _call_with_growing_buffer
 

--- a/python/rascaline/splines.py
+++ b/python/rascaline/splines.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 
 

--- a/python/rascaline/status.py
+++ b/python/rascaline/status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ._c_api import RASCAL_SUCCESS
 from ._c_lib import _get_library
 

--- a/python/rascaline/systems/base.py
+++ b/python/rascaline/systems/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 from ctypes import POINTER, c_double, c_void_p, pointer
 

--- a/python/rascaline/utils.py
+++ b/python/rascaline/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 from ._c_api import RASCAL_BUFFER_SIZE_ERROR

--- a/python/rascaline/utils.py
+++ b/python/rascaline/utils.py
@@ -1,4 +1,7 @@
 import ctypes
+import os
+
+import equistore
 
 from ._c_api import RASCAL_BUFFER_SIZE_ERROR
 from .status import RascalError
@@ -19,3 +22,13 @@ def _call_with_growing_buffer(callback, initial=1024):
             else:
                 raise
     return buffer.value.decode("utf8")
+
+
+# path that can be used with cmake to access the rascaline library and headers
+_HERE = os.path.realpath(os.path.dirname(__file__))
+cmake_prefix_path = (
+    f"{os.path.join(_HERE, 'lib', 'cmake')};{equistore.utils.cmake_prefix_path}"
+)
+"""
+Path containing the CMake configuration files for the underlying C library
+"""

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 import os
-import sys
 
 from pycparser import c_ast, parse_file
 
@@ -210,7 +208,7 @@ def generate_structs(file, structs):
 
 
 def generate_functions(file, functions):
-    file.write(f"\n\ndef setup_functions(lib):\n")
+    file.write("\n\ndef setup_functions(lib):\n")
     file.write("    from .status import _check_rascal_status_t\n")
 
     for function in functions:
@@ -236,8 +234,7 @@ def generate_declarations():
     outpath = os.path.join(ROOT, "..", "rascaline", "_c_api.py")
     with open(outpath, "w") as file:
         file.write(
-            """# -*- coding: utf-8 -*-
-'''Automatically-generated file, do not edit!!!'''
+            """'''Automatically-generated file, do not edit!!!'''
 # flake8: noqa
 
 import ctypes

--- a/python/tests/calculators.py
+++ b/python/tests/calculators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 import numpy as np

--- a/python/tests/log.py
+++ b/python/tests/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 from rascaline import set_logging_callback

--- a/python/tests/misc.py
+++ b/python/tests/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/python/tests/misc.py
+++ b/python/tests/misc.py
@@ -6,11 +6,16 @@ import rascaline
 
 class TestCMakePrefixPath(unittest.TestCase):
     def test_cmake_prefix_path_exists(self):
-        self.assertTrue(hasattr(rascaline._c_lib, "cmake_prefix_path"))
-        self.assertTrue(isinstance(rascaline._c_lib.cmake_prefix_path, str))
+        self.assertTrue(hasattr(rascaline.utils, "cmake_prefix_path"))
+        self.assertTrue(isinstance(rascaline.utils.cmake_prefix_path, str))
+
+        # there is both the path to equistore and rascaline cmake prefix in here
+        self.assertEqual(len(rascaline.utils.cmake_prefix_path.split(";")), 2)
 
     def test_cmake_files_exists(self):
-        cmake = os.path.join(rascaline._c_lib.cmake_prefix_path, "rascaline")
+        rascaline_cmake_path = rascaline.utils.cmake_prefix_path.split(";")[0]
+        cmake = os.path.join(rascaline_cmake_path, "rascaline")
+
         self.assertTrue(os.path.isfile(os.path.join(cmake, "rascaline-config.cmake")))
         self.assertTrue(
             os.path.isfile(os.path.join(cmake, "rascaline-config-version.cmake"))

--- a/python/tests/splines.py
+++ b/python/tests/splines.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 import numpy as np

--- a/python/tests/systems/ase.py
+++ b/python/tests/systems/ase.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 import numpy as np

--- a/python/tests/systems/chemfiles.py
+++ b/python/tests/systems/chemfiles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 import numpy as np

--- a/python/tests/systems/errors.py
+++ b/python/tests/systems/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 from rascaline import RascalError

--- a/python/tests/test_systems.py
+++ b/python/tests/test_systems.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from rascaline import SystemBase
 
 

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -185,6 +185,7 @@ set(RASCALINE_HEADERS
 set(RASCALINE_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/)
 
 set(EQUISTORE_GIT_VERSION "6c5a833")
+set(EQUISTORE_REQUIRED_VERSION "0.1")
 if (RASCALINE_FETCH_EQUISTORE)
     message(STATUS "Fetching equistore @ ${EQUISTORE_GIT_VERSION} from github")
 
@@ -215,7 +216,7 @@ if (RASCALINE_FETCH_EQUISTORE)
 
     add_dependencies(cargo-build-rascaline equistore)
 else()
-    find_package(equistore 0.1 REQUIRED CONFIG)
+    find_package(equistore ${EQUISTORE_REQUIRED_VERSION} REQUIRED CONFIG)
 endif()
 
 set_target_properties(rascaline PROPERTIES

--- a/rascaline-c-api/cmake/rascaline-config.in.cmake
+++ b/rascaline-c-api/cmake/rascaline-config.in.cmake
@@ -5,9 +5,7 @@ if(rascaline_FOUND)
 endif()
 
 cmake_minimum_required(VERSION 3.10)
-
 enable_language(CXX)
-find_package(equistore 0.1 REQUIRED CONFIG)
 
 if (@BUILD_SHARED_LIBS@)
     add_library(rascaline SHARED IMPORTED GLOBAL)
@@ -15,12 +13,31 @@ else()
     add_library(rascaline STATIC IMPORTED GLOBAL)
 endif()
 
+# check that all expected files exist
+if (NOT EXISTS ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@RASCALINE_LIB_NAME@)
+    message(FATAL_ERROR "unable to find rascaline library at ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@RASCALINE_LIB_NAME@")
+endif()
+
+if (NOT EXISTS ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/rascaline.h)
+    message(FATAL_ERROR "unable to find rascaline header at ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/rascaline.h")
+endif()
+
+if (NOT EXISTS ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/rascaline.hpp)
+    message(FATAL_ERROR "unable to find rascaline header at ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/rascaline.hpp")
+endif()
+
+
+# create an imported rascaline target
 set_target_properties(rascaline PROPERTIES
     IMPORTED_LOCATION ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@RASCALINE_LIB_NAME@
     INTERFACE_INCLUDE_DIRECTORIES ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/
-    # we need to link with a C++ compiler to get the C++ stdlib for chemfiles
+    # we might need to link with a C++ compiler to get the C++ stdlib for
+    # chemfiles, if the chemfiles feature is enabled
     IMPORTED_LINK_INTERFACE_LANGUAGES CXX
 )
+
+
+find_package(equistore @EQUISTORE_REQUIRED_VERSION@ REQUIRED CONFIG)
 target_link_libraries(rascaline INTERFACE equistore)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import shutil
 import subprocess
 
 from setuptools import Extension, setup
@@ -82,9 +83,12 @@ class cmake_ext(build_ext):
             check=True,
         )
 
-        # do not include equistore libraries/headers with rascaline wheel
+        # do not include equistore libraries/headers/cmake config within
+        # rascaline wheel
         for file in glob.glob(os.path.join(install_dir, "lib", "*equistore*")):
             os.unlink(file)
+
+        shutil.rmtree(os.path.join(install_dir, "lib", "cmake", "equistore"))
 
         for file in glob.glob(os.path.join(install_dir, "include", "equistore*")):
             os.unlink(file)


### PR DESCRIPTION
This feature is used in rascaline-torch. This PR does three things:

- move `find_package(equistore)` to a later stage, otherwise it overwrites the `PACKAGE_PREFIX_DIR` variable
- do not include equistore cmake files in rascaline wheel
- add checks that the installation contains all the required files

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--172.org.readthedocs.build/en/172/

<!-- readthedocs-preview rascaline end -->