### PR TITLE
Allow for float exponentials in willatts radial scaling function

### DIFF
--- a/rascaline/src/calculators/soap/cutoff.rs
+++ b/rascaline/src/calculators/soap/cutoff.rs
@@ -77,7 +77,7 @@ pub enum RadialScaling {
     Willatt2018 {
         scale: f64,
         rate: f64,
-        exponent: i32,
+        exponent: f64,
     },
 }
 
@@ -106,7 +106,7 @@ impl RadialScaling {
                     )));
                 }
 
-                if *exponent <= 0 {
+                if *exponent <= 0.0 {
                     return Err(Error::InvalidParameter(format!(
                         "expected positive exponent for Willatt2018 radial scaling function, got {}",
                         exponent
@@ -122,7 +122,7 @@ impl RadialScaling {
         match self {
             RadialScaling::None {} => 1.0,
             RadialScaling::Willatt2018 { rate, scale, exponent } => {
-                rate / (rate + (r / scale).powi(*exponent))
+                rate / (rate + (r / scale).powf(*exponent))
             }
         }
     }
@@ -133,7 +133,7 @@ impl RadialScaling {
             RadialScaling::None {} => 0.0,
             RadialScaling::Willatt2018 { scale, rate, exponent } => {
                 let rs = r / scale;
-                let rs_m1 = rs.powi(exponent - 1);
+                let rs_m1 = rs.powf(exponent - 1.0);
                 let rs_m = rs * rs_m1;
                 let factor = - rate * (*exponent as f64) / scale;
 

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -780,7 +780,7 @@ mod tests {
             atomic_gaussian_width: 0.3,
             center_atom_weight: 1.0,
             radial_basis: RadialBasis::splined_gto(1e-8),
-            radial_scaling: RadialScaling::Willatt2018 { scale: 1.5, rate: 0.8, exponent: 2},
+            radial_scaling: RadialScaling::Willatt2018 { scale: 1.5, rate: 0.8, exponent: 2.0},
             cutoff_function: CutoffFunction::ShiftedCosine { width: 0.5 },
         }
     }

--- a/rascaline/src/calculators/soap/spherical_expansion_pair.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion_pair.rs
@@ -833,7 +833,7 @@ mod tests {
             atomic_gaussian_width: 0.3,
             center_atom_weight: 1.0,
             radial_basis: RadialBasis::splined_gto(1e-8),
-            radial_scaling: RadialScaling::Willatt2018 { scale: 1.5, rate: 0.8, exponent: 2},
+            radial_scaling: RadialScaling::Willatt2018 { scale: 1.5, rate: 0.8, exponent: 2.0},
             cutoff_function: CutoffFunction::ShiftedCosine { width: 0.5 },
         }
     }


### PR DESCRIPTION
Hello,

for better compatibility with librascal I propose to allow the use of non-integer exponentials in the calculation of the
radial scaling functions.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--196.org.readthedocs.build/en/196/

<!-- readthedocs-preview rascaline end -->