### PR TITLE
Bump minimal Rustc version to 1.63

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
             cargo-build-flags: --release
             do-valgrind: true
           - os: ubuntu-20.04
-            rust-version: 1.61
+            rust-version: 1.63
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
           - os: ubuntu-20.04
@@ -45,7 +45,7 @@ jobs:
           # check the build on a stock Ubuntu 20.04, including cmake 3.16 and
           # Python 3.8
           - os: ubuntu-20.04
-            rust-version: "1.61"
+            rust-version: "1.63"
             container: ubuntu:20.04
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     - cmake
   tools:
     python: "3.10"
-    rust: "1.64"
+    rust: "1.64"  # RDT does not offer our minimal version 1.63
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     - cmake
   tools:
     python: "3.10"
-    rust: "1.61"
+    rust: "1.64"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,7 +57,7 @@ on rascaline:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.61 to build rascaline.
+  1.63 to build rascaline.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.6.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/docs/rascaline-json-schema/Cargo.toml
+++ b/docs/rascaline-json-schema/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2018"
 publish = false
-rust-version = "1.61"
+rust-version = "1.63"
 
 [[bin]]
 name = "rascaline-json-schema"

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -103,24 +103,15 @@ if(CARGO_STATUS AND NOT CARGO_STATUS EQUAL 0)
     )
 endif()
 
-set(REQUIRED_RUST_VERSION "1.61.0")
 if (CARGO_VERSION_RAW MATCHES "cargo ([0-9]+\\.[0-9]+\\.[0-9]+).*")
     set(CARGO_VERSION "${CMAKE_MATCH_1}")
 else()
     message(FATAL_ERROR "failed to determine cargo version, output was: ${CARGO_VERSION_RAW}")
 endif()
-
-if (${CARGO_VERSION} VERSION_LESS ${REQUIRED_RUST_VERSION})
-    message(FATAL_ERROR
-        "your Rust installation is too old (you have version ${CARGO_VERSION}), \
-        at least ${REQUIRED_RUST_VERSION} is required"
-    )
-else()
-    if(NOT "${CACHED_LAST_CARGO_VERSION}" STREQUAL ${CARGO_VERSION})
-        set(CACHED_LAST_CARGO_VERSION ${CARGO_VERSION} CACHE INTERNAL "Last version of cargo used in configuration")
-        message(STATUS "Using cargo version ${CARGO_VERSION} at ${CARGO_EXE}")
-        set(CARGO_VERSION_CHANGED TRUE)
-    endif()
+if(NOT "${CACHED_LAST_CARGO_VERSION}" STREQUAL ${CARGO_VERSION})
+    set(CACHED_LAST_CARGO_VERSION ${CARGO_VERSION} CACHE INTERNAL "Last version of cargo used in configuration")
+    message(STATUS "Using cargo version ${CARGO_VERSION} at ${CARGO_EXE}")
+    set(CARGO_VERSION_CHANGED TRUE)
 endif()
 
 # ============================================================================ #

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -3,7 +3,7 @@ name = "rascaline-c-api"
 version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [lib]
 # when https://github.com/rust-lang/cargo/pull/8789 lands, use it here!

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -3,7 +3,7 @@ name = "rascaline"
 version = "0.1.0"
 authors = ["Luthaf <luthaf@luthaf.fr>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [lib]
 bench = false


### PR DESCRIPTION
See https://github.com/lab-cosmo/equistore/pull/308


<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview rascaline end -->