### PR TITLE
Newer Python version for upper bound CI test

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: install dependencies
         run: python -m pip install cibuildwheel
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: build sdist
         run: |
           pip install wheel

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install dependencies
         run: |
           pip install tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,29 +21,38 @@ jobs:
           - os: ubuntu-20.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.7"
             build-type: debug
           - os: ubuntu-20.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.11"
+            build-type: debug
+          - os: ubuntu-20.04
+            rust-version: stable
+            rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.11"
             build-type: debug
             test-static-lib: true
             extra-name: static C library
           - os: ubuntu-20.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.11"
             build-type: release
             cargo-build-flags: --release
             do-valgrind: true
           - os: ubuntu-20.04
-            rust-version: 1.63
+            rust-version: "1.63"
             rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.11"
             build-type: debug
           - os: ubuntu-20.04
             rust-version: beta
             rust-target: x86_64-unknown-linux-gnu
+            python-version: "3.11"
             build-type: debug
-          # check the build on a stock Ubuntu 20.04, including cmake 3.16 and
-          # Python 3.8
+          # check the build on a stock Ubuntu 20.04, including cmake 3.16 and Python 3.8
           - os: ubuntu-20.04
             rust-version: "1.63"
             container: ubuntu:20.04
@@ -52,6 +61,7 @@ jobs:
           - os: macos-11
             rust-version: stable
             rust-target: x86_64-apple-darwin
+            python-version: "3.11"
             build-type: debug
     steps:
       - name: install dependencies in container
@@ -68,7 +78,7 @@ jobs:
         uses: actions/setup-python@v4
         if: "!matrix.container"
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - cmake
   tools:
-    python: "3.10"
+    python: "3.11"
     rust: "1.64"  # RDT does not offer our minimal version 1.63
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Lifting the Python version in the CI to 3.11. Additionally I added a new CI job to test our minimal supported Python version.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--208.org.readthedocs.build/en/208/

<!-- readthedocs-preview rascaline end -->