### PR TITLE
Warn instead of erroring if center_contribution is given to SOAP radial integral

### DIFF
--- a/rascaline-c-api/src/calculator.rs
+++ b/rascaline-c-api/src/calculator.rs
@@ -151,6 +151,7 @@ pub unsafe extern fn rascal_calculator_parameters(
 }
 
 
+#[allow(clippy::doc_markdown)]
 /// Get all radial cutoffs used by this `calculator`'s neighbors lists (which
 /// can be an empty list).
 ///
@@ -189,6 +190,7 @@ pub unsafe extern fn rascal_calculator_cutoffs(
 /// to NULL.
 #[repr(C)]
 #[derive(Debug)]
+#[allow(non_camel_case_types)]
 pub struct rascal_labels_selection_t {
     /// Select a subset of labels, using the same selection criterion for all
     /// keys in the final `eqs_tensormap_t`.
@@ -296,8 +298,9 @@ fn key_selection(value: *const eqs_labels_t, labels: &'_ mut Option<Labels>) -> 
 }
 
 /// Options that can be set to change how a calculator operates.
-#[derive(Debug)]
 #[repr(C)]
+#[derive(Debug)]
+#[allow(non_camel_case_types)]
 pub struct rascal_calculation_options_t {
     /// @verbatim embed:rst:leading-asterisk
     /// Array of NULL-terminated strings containing the gradients to compute.

--- a/rascaline-c-api/src/logging.rs
+++ b/rascaline-c-api/src/logging.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CString};
+use std::ffi::CString;
 use std::sync::Mutex;
 
 use log::{Record, Metadata};

--- a/rascaline-c-api/src/system.rs
+++ b/rascaline-c-api/src/system.rs
@@ -11,6 +11,7 @@ use super::{catch_unwind, rascal_status_t};
 
 /// Pair of atoms coming from a neighbor list
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct rascal_pair_t {
     /// index of the first atom in the pair
     pub first: usize,
@@ -55,6 +56,7 @@ pub struct rascal_pair_t {
 // Finally `extern` defaults to `extern "C"`, setting the ABI of the function to
 // the default C ABI on the current system.
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct rascal_system_t {
     /// User-provided data should be stored here, it will be passed as the
     /// first parameter to all function pointers below.

--- a/rascaline/src/calculators/soap/radial_integral/mod.rs
+++ b/rascaline/src/calculators/soap/radial_integral/mod.rs
@@ -1,5 +1,7 @@
 use ndarray::{ArrayViewMut2, Array2};
 
+use log::warn;
+
 use crate::Error;
 use crate::calculators::radial_basis::RadialBasis;
 
@@ -112,11 +114,12 @@ impl SoapRadialIntegralCache {
                 };
 
                 if center_contribution.is_some() {
-                    Error::InvalidParameter(
-                        "For a tabulated radial integral with SOAP the
-                        `center_contribution` is superflous.".into());
+                    warn!(
+                        "`center_contribution` is not used in SOAP radial \
+                        integral and will be ignored"
+                    );
                 }
-                
+
                 Box::new(SoapRadialIntegralSpline::from_tabulated(
                     parameters, points
                 )?)


### PR DESCRIPTION
This is a follow up to #204.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview rascaline end -->