### PR TITLE
Add option to fill all species  when computing `PowerSpectrum` 

### DIFF
--- a/python/rascaline/tests/utils/power_spectrum.py
+++ b/python/rascaline/tests/utils/power_spectrum.py
@@ -151,3 +151,21 @@ def test_power_spectrum_unknown_gradient() -> None:
     msg = "PowerSpectrum currently only supports gradients w.r.t. to positions"
     with pytest.raises(NotImplementedError, match=msg):
         PowerSpectrum(calculator).compute(SystemForTests(), gradients=["cell"])
+
+
+def test_fill_species_neighbor() -> None:
+    """Test that ``species_center`` keys can be merged for different blocks."""
+
+    frames = [
+        ase.Atoms("H", positions=np.zeros([1, 3])),
+        ase.Atoms("O", positions=np.zeros([1, 3])),
+    ]
+
+    calculator = PowerSpectrum(
+        calculator_1=rascaline.SphericalExpansion(**HYPERS),
+        calculator_2=rascaline.SphericalExpansion(**HYPERS),
+    )
+
+    descriptor = calculator.compute(frames)
+
+    descriptor.keys_to_samples("species_center")


### PR DESCRIPTION
Possible fix for #213.

This adds the option `fill_species_neighbor ` to the compute method of  `PowerSpectrum`. Setting this to `True` changes `keys_to_move` when performing `keys_to_properties` in such a way that it contains all species of the provided systems.

I am not super happy with the name of the parameter but I think the it should be part of the the compute method.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--214.org.readthedocs.build/en/214/

<!-- readthedocs-preview rascaline end -->