### PR TITLE
Make rascaline-torch an optional dependency of rascaline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rascaline"
-dynamic = ["version", "authors"]
+dynamic = ["version", "authors", "optional-dependencies"]
 requires-python = ">=3.7"
 
 readme = "README.rst"

--- a/python/rascaline-torch/build-backend/backend.py
+++ b/python/rascaline-torch/build-backend/backend.py
@@ -18,7 +18,7 @@ if os.path.exists(os.path.join(RASCALINE, "rascaline-c-api")):
     RASCALINE_DEP = f"rascaline @ file://{RASCALINE}?{uuid}"
 else:
     # we are building from a sdist
-    RASCALINE_DEP = "rascaline == 0.1.0"
+    RASCALINE_DEP = "rascaline >=0.1.0.dev0,<0.2.0"
 
 
 prepare_metadata_for_build_wheel = build_meta.prepare_metadata_for_build_wheel

--- a/python/rascaline-torch/setup.py
+++ b/python/rascaline-torch/setup.py
@@ -238,10 +238,13 @@ if __name__ == "__main__":
         with open(os.path.join(ROOT, authors[0])) as fd:
             authors = fd.read().splitlines()
 
-    install_requires = ["torch >= 1.11"]
+    install_requires = [
+        "torch >= 1.11",
+        "metatensor-torch",
+    ]
     if os.path.exists(RASCALINE_C_API):
         # we are building from a git checkout
-        rascaline_path = os.path.join(ROOT, "..", "..")
+        rascaline_path = os.path.realpath(os.path.join(ROOT, "..", ".."))
 
         # add a random uuid to the file url to prevent pip from using a cached
         # wheel for rascaline, and force it to re-build from scratch


### PR DESCRIPTION
Trying to run `pip install .[torch]` from source will fail with an error like this:

```
INFO: pip is looking at multiple versions of metatensor-torch to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install rascaline-torch, rascaline==0.1.0.dev457 and rascaline[torch]==0.1.0.dev457 because these package versions have conflicting dependencies.

The conflict is caused by:
    rascaline[torch] 0.1.0.dev457 depends on metatensor-core 0.1.0 (from https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip#subdirectory=python/metatensor-core)
    rascaline 0.1.0.dev457 depends on metatensor-core 0.1.0 (from https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip#subdirectory=python/metatensor-core)
    metatensor-torch 0.1.0 depends on metatensor-core 0.1.0 (from /private/var/folders/nz/mgmqnhrj4mzfjlnqbgn02t780000gn/T/pip-install-v_q_c4ik/metatensor-torch_49679123430840aca28a7d2b54835964/python/metatensor-core)
```

This is a known limitation of pip, that will be lifted once we have metatensor on PyPI (soon!). In the mean time, this code should allow to install `rascaline[torch]` from https://github.com/Luthaf/nightly-wheels.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--230.org.readthedocs.build/en/230/

<!-- readthedocs-preview rascaline end -->