### PR TITLE
Update metatensor

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ myst-parser     # markdown => rst translation, used in extensions/rascaline_json
 
 # dependencies for the tutorials
 --extra-index-url https://download.pytorch.org/whl/cpu
-metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip
+metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip
 torch
 chemfiles
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "metatensor-core @ https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip#subdirectory=python/metatensor-core",
+    "metatensor-core @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip#subdirectory=python/metatensor-core",
 ]
 
 [project.urls]

--- a/python/rascaline-torch/pyproject.toml
+++ b/python/rascaline-torch/pyproject.toml
@@ -38,7 +38,7 @@ requires = [
     "wheel >=0.38",
     "cmake",
     "torch >= 1.11",
-    "metatensor-torch @ https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip#subdirectory=python/metatensor-torch",
+    "metatensor-torch @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip#subdirectory=python/metatensor-torch",
 ]
 
 # use a custom build backend to add a dependency on the right version of rascaline

--- a/python/rascaline/examples/property-selection.py
+++ b/python/rascaline/examples/property-selection.py
@@ -6,7 +6,7 @@ Property Selection
 """
 import chemfiles
 import numpy as np
-from metatensor.core import Labels, MetatensorError, TensorBlock, TensorMap
+from metatensor import Labels, MetatensorError, TensorBlock, TensorMap
 from skmatter.feature_selection import FPS
 
 from rascaline import SoapPowerSpectrum

--- a/python/rascaline/rascaline/_c_api.py
+++ b/python/rascaline/rascaline/_c_api.py
@@ -7,7 +7,7 @@ import enum
 import platform
 from ctypes import CFUNCTYPE, POINTER
 
-from metatensor.core._c_api import mts_labels_t, mts_tensormap_t
+from metatensor._c_api import mts_labels_t, mts_tensormap_t
 from numpy.ctypeslib import ndpointer
 
 
@@ -85,7 +85,7 @@ def setup_functions(lib):
     from .status import _check_rascal_status_t
 
     lib.rascal_last_error.argtypes = [
-        
+
     ]
     lib.rascal_last_error.restype = ctypes.c_char_p
 
@@ -149,7 +149,7 @@ def setup_functions(lib):
     lib.rascal_calculator_compute.restype = _check_rascal_status_t
 
     lib.rascal_profiling_clear.argtypes = [
-        
+
     ]
     lib.rascal_profiling_clear.restype = _check_rascal_status_t
 

--- a/python/rascaline/rascaline/_c_lib.py
+++ b/python/rascaline/rascaline/_c_lib.py
@@ -2,7 +2,7 @@ import os
 import sys
 from ctypes import cdll
 
-import metatensor.core
+import metatensor
 
 from ._c_api import setup_functions
 from .log import _set_logging_callback_impl, default_logging_callback
@@ -19,7 +19,7 @@ class RascalFinder(object):
         if self._cached_dll is None:
             # Load metatensor shared library in the process first, to ensure
             # the rascaline shared library can find it
-            metatensor.core._c_lib._get_library()
+            metatensor._c_lib._get_library()
 
             path = _lib_path()
 

--- a/python/rascaline/rascaline/calculator_base.py
+++ b/python/rascaline/rascaline/calculator_base.py
@@ -1,8 +1,8 @@
 import ctypes
 from typing import List, Optional, Union
 
-from metatensor.core import Labels, TensorMap
-from metatensor.core._c_api import c_uintptr_t, mts_tensormap_t
+from metatensor import Labels, TensorMap
+from metatensor._c_api import c_uintptr_t, mts_tensormap_t
 
 from ._c_api import (
     RASCAL_BUFFER_SIZE_ERROR,

--- a/python/rascaline/rascaline/utils/__init__.py
+++ b/python/rascaline/rascaline/utils/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-import metatensor.core
+import metatensor
 
 from .power_spectrum import PowerSpectrum
 
@@ -12,9 +12,7 @@ __all__ = ["PowerSpectrum"]
 _HERE = os.path.realpath(os.path.dirname(__file__))
 
 _rascaline_cmake_prefix = os.path.realpath(os.path.join(_HERE, "..", "lib", "cmake"))
-cmake_prefix_path = (
-    f"{_rascaline_cmake_prefix};{metatensor.core.utils.cmake_prefix_path}"
-)
+cmake_prefix_path = f"{_rascaline_cmake_prefix};{metatensor.utils.cmake_prefix_path}"
 """
 Path containing the CMake configuration files for the underlying C library
 """

--- a/python/rascaline/rascaline/utils/power_spectrum/_classes.py
+++ b/python/rascaline/rascaline/utils/power_spectrum/_classes.py
@@ -1,4 +1,4 @@
-from metatensor.core import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorBlock, TensorMap
 
 from ...calculator_base import CalculatorBase
 from ...systems import IntoSystem

--- a/python/rascaline/tests/calculators/keys_selection.py
+++ b/python/rascaline/tests/calculators/keys_selection.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from metatensor.core import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorBlock, TensorMap
 
 from rascaline import RascalError
 from rascaline.calculators import DummyCalculator

--- a/python/rascaline/tests/calculators/properties_selection.py
+++ b/python/rascaline/tests/calculators/properties_selection.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from metatensor.core import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorBlock, TensorMap
 
 from rascaline import RascalError
 from rascaline.calculators import DummyCalculator

--- a/python/rascaline/tests/calculators/sample_selection.py
+++ b/python/rascaline/tests/calculators/sample_selection.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from metatensor.core import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorBlock, TensorMap
 
 from rascaline import RascalError
 from rascaline.calculators import DummyCalculator

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 import os
 
-import metatensor.core
+import metatensor
 from pycparser import c_ast, parse_file
 
 
 ROOT = os.path.dirname(__file__)
 FAKE_INCLUDES = os.path.join(ROOT, "include")
 METATENSOR_INCLUDE = os.path.join(
-    metatensor.core.utils.cmake_prefix_path, "..", "..", "include"
+    metatensor.utils.cmake_prefix_path, "..", "..", "include"
 )
 RASCALINE_HEADER = os.path.relpath(
     os.path.join(ROOT, "..", "..", "rascaline-c-api", "include", "rascaline.h")
@@ -248,7 +248,7 @@ import enum
 import platform
 from ctypes import CFUNCTYPE, POINTER
 
-from metatensor.core._c_api import mts_labels_t, mts_tensormap_t
+from metatensor._c_api import mts_labels_t, mts_tensormap_t
 from numpy.ctypeslib import ndpointer
 
 

--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 # ============================================================================ #
 # Setup metatensor
 
-set(METATENSOR_GIT_VERSION "d97ea65")
+set(METATENSOR_GIT_VERSION "2248a3c")
 set(METATENSOR_REQUIRED_VERSION "0.1")
 if (RASCALINE_FETCH_METATENSOR)
     message(STATUS "Fetching metatensor @ ${METATENSOR_GIT_VERSION} from github")
@@ -226,7 +226,7 @@ if (RASCALINE_FETCH_METATENSOR)
     FetchContent_Declare(
         metatensor
         URL      https://github.com/lab-cosmo/metatensor/archive/${METATENSOR_GIT_VERSION}.zip
-        URL_HASH MD5=6a6899779591ae15861bb3547c7c354b
+        URL_HASH MD5=50e70a2e74246a985e1520260a74205c
         SOURCE_SUBDIR metatensor-core
         VERBOSE
     )

--- a/rascaline-c-api/Cargo.toml
+++ b/rascaline-c-api/Cargo.toml
@@ -18,7 +18,7 @@ chemfiles = ["rascaline/chemfiles"]
 
 [dependencies]
 rascaline = {path = "../rascaline", version = "0.1.0", default-features = false}
-metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "d97ea65"}
+metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "2248a3c"}
 
 ndarray = "0.15"
 log = { version = "0.4", features = ["std"] }
@@ -29,7 +29,7 @@ libc = "0.2"
 [build-dependencies]
 cbindgen = { version = "0.24", default-features = false }
 fs_extra = "1"
-metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "d97ea65"}
+metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "2248a3c"}
 
 [dev-dependencies]
 which = "4"

--- a/rascaline-torch/CMakeLists.txt
+++ b/rascaline-torch/CMakeLists.txt
@@ -58,7 +58,7 @@ find_package(Torch 1.11 REQUIRED)
 # ============================================================================ #
 # Setup metatensor_torch
 
-set(METATENSOR_GIT_VERSION "d97ea65")
+set(METATENSOR_GIT_VERSION "2248a3c")
 set(REQUIRED_METATENSOR_TORCH_VERSION "0.1")
 if (RASCALINE_TORCH_FETCH_METATENSOR_TORCH)
     message(STATUS "Fetching metatensor_torch @ ${METATENSOR_GIT_VERSION} from github")
@@ -67,7 +67,7 @@ if (RASCALINE_TORCH_FETCH_METATENSOR_TORCH)
     FetchContent_Declare(
         metatensor_torch
         URL      https://github.com/lab-cosmo/metatensor/archive/${METATENSOR_GIT_VERSION}.zip
-        URL_HASH MD5=6a6899779591ae15861bb3547c7c354b
+        URL_HASH MD5=50e70a2e74246a985e1520260a74205c
         SOURCE_SUBDIR metatensor-torch
         VERBOSE
     )

--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -36,7 +36,7 @@ name = "soap-power-spectrum"
 harness = false
 
 [dependencies]
-metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "d97ea65", features = ["rayon"]}
+metatensor = {git = "https://github.com/lab-cosmo/metatensor", rev = "2248a3c", features = ["rayon"]}
 
 ndarray = {version = "0.15", features = ["approx-0_5", "rayon", "serde"]}
 num-traits = "0.2"

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,10 @@ lint-folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 # we need to manually install dependencies for rascaline, since tox will install
 # the fresh wheel with `--no-deps` after building it.
 metatensor-core-requirement =
-    metatensor-core @ https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip\#subdirectory=python/metatensor-core
+    metatensor-core @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip\#subdirectory=python/metatensor-core
 
 metatensor-torch-requirement =
-    metatensor-torch @ https://github.com/lab-cosmo/metatensor/archive/d97ea65.zip\#subdirectory=python/metatensor-torch
+    metatensor-torch @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip\#subdirectory=python/metatensor-torch
 
 build-single-wheel = --no-deps --no-build-isolation --check-build-dependencies
 


### PR DESCRIPTION
`metatensor.core` has been removed and all the corresponding code is now available in `metatensor`.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--232.org.readthedocs.build/en/232/

<!-- readthedocs-preview rascaline end -->