### PR TITLE
subtraction theorem exploited in LODE structure factor

### DIFF
--- a/rascaline/src/calculators/lode/spherical_expansion.rs
+++ b/rascaline/src/calculators/lode/spherical_expansion.rs
@@ -144,14 +144,14 @@ fn compute_structure_factors(positions: &[Vector3D], species: &[i32], k_vectors:
  
     // Compute Sum_j cos(k*r_ij) and Sum_j sin(k*r_ij) using the subtraction theorem
     for i in 0..n_atoms {
-        for (species, structfactreal) in &mut real_per_center {
+        for (species, real_per_center) in &mut real_per_center {
             let sumjcos = sumjcos.get_mut(&species).unwrap();
             let sumjsin = sumjsin.get_mut(&species).unwrap();
             let imag_per_center = imag_per_center.get_mut(&species).unwrap();
             for k in 0..n_k_vectors {
                 let real = cosines[[i, k]] * sumjcos[k] + sines[[i, k]] * sumjsin[k]; 
                 let imag = sines[[i, k]] * sumjcos[k] - cosines[[i, k]] * sumjsin[k];
-                structfactreal[[i, k]] += 2.0 * real;
+                real_per_center[[i, k]] += 2.0 * real;
                 imag_per_center[[i, k]] += 2.0 * imag;
             }
         }


### PR DESCRIPTION
Subtraction theorem exploited when computing the LODE structure factor in order to remove the double sum over atoms.

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--242.org.readthedocs.build/en/242/

<!-- readthedocs-preview rascaline end -->