### PR TITLE
Add a (-1)^l factor to the power spectrum invariants

### DIFF
--- a/python/rascaline/rascaline/utils/power_spectrum/calculator.py
+++ b/python/rascaline/rascaline/utils/power_spectrum/calculator.py
@@ -217,7 +217,10 @@ class PowerSpectrum:
             ell = key[0]
             species_center = key[1]
 
-            factor = 1 / sqrt(2 * ell + 1)
+            # For consistency with a full Clebsch-Gordan product we need to add
+            # a `-1^l / sqrt(2 l + 1)` factor to the power spectrum invariants
+            factor = (-1) ** ell / sqrt(2 * ell + 1)
+
             # Find that block indices that have the same spherical_harmonics_l and
             # species_center
             selection = Labels(

--- a/rascaline/tests/soap-power-spectrum.rs
+++ b/rascaline/tests/soap-power-spectrum.rs
@@ -24,8 +24,10 @@ fn values() {
     let block = &descriptor.block_by_id(0);
     let array = block.values().to_array();
 
-   let expected = &data::load_expected_values("soap-power-spectrum-values.npy.gz");
-   assert_relative_eq!(array, expected, max_relative=1e-5);
+    let mut expected = data::load_expected_values("soap-power-spectrum-values.npy.gz");
+    correct_factor(&mut expected, block.properties());
+
+    assert_relative_eq!(array, &expected, max_relative=1e-5);
 }
 
 #[test]
@@ -51,13 +53,15 @@ fn gradients() {
     let gradients = block.gradient("positions").unwrap();
     let array = sum_gradients(n_atoms, gradients);
 
-    let expected = &data::load_expected_values("soap-power-spectrum-positions-gradient.npy.gz");
-    assert_relative_eq!(array, expected, max_relative=1e-6);
+    let mut expected = data::load_expected_values("soap-power-spectrum-positions-gradient.npy.gz");
+    correct_factor(&mut expected, block.properties());
+    assert_relative_eq!(array, &expected, max_relative=1e-6);
 
     let gradient = block.gradient("cell").unwrap();
     let array = gradient.values().to_array();
-    let expected = &data::load_expected_values("soap-power-spectrum-cell-gradient.npy.gz");
-    assert_relative_eq!(array, expected, max_relative=1e-6);
+    let mut expected = data::load_expected_values("soap-power-spectrum-cell-gradient.npy.gz");
+    correct_factor(&mut expected, block.properties());
+    assert_relative_eq!(array, &expected, max_relative=1e-6);
 }
 
 fn sum_gradients(n_atoms: usize, gradients: TensorBlockRef<'_>) -> ArrayD<f64> {
@@ -71,4 +75,16 @@ fn sum_gradients(n_atoms: usize, gradients: TensorBlockRef<'_>) -> ArrayD<f64> {
     }
 
     sum
+}
+
+
+// Add back the missing (-1)^l factor to the reference data
+fn correct_factor(reference: &mut ndarray::ArrayD<f64>, properties: Labels) {
+    assert!(properties.names() == [ "species_neighbor_1", "species_neighbor_2", "l", "n1", "n2"]);
+
+    let last_axis = reference.shape().len() - 1;
+
+    for (&[_, _, l, _, _], mut column) in properties.iter_fixed_size().zip(reference.axis_iter_mut(Axis(last_axis))) {
+        column *= (-1.0_f64).powi(l.i32());
+    }
 }

--- a/scripts/clean-python.sh
+++ b/scripts/clean-python.sh
@@ -10,6 +10,7 @@ cd "$ROOT_DIR"
 
 rm -rf dist
 rm -rf build
+rm -rf .coverage
 
 rm -rf python/rascaline-torch/dist
 rm -rf python/rascaline-torch/build


### PR DESCRIPTION
This make the power spectrum produce the same output as doing a full Clebsch-Gordan product and keeping only the lambda=0 term

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--248.org.readthedocs.build/en/248/

<!-- readthedocs-preview rascaline end -->