### PR TITLE
Fix serialization of calculators in torch

### DIFF
--- a/python/rascaline-torch/tests/calculator.py
+++ b/python/rascaline-torch/tests/calculator.py
@@ -190,3 +190,4 @@ def test_script(tmpdir):
 
     with tmpdir.as_cwd():
         torch.jit.save(module, "test-save.torch")
+        module = torch.jit.load("test-save.torch")

--- a/rascaline-torch/include/rascaline/torch/calculator.hpp
+++ b/rascaline-torch/include/rascaline/torch/calculator.hpp
@@ -75,12 +75,18 @@ class RASCALINE_TORCH_EXPORT CalculatorHolder: public torch::CustomClassHolder {
 public:
     /// Create a new calculator with the given `name` and JSON `parameters`
     CalculatorHolder(std::string name, std::string parameters):
-        calculator_(std::move(name), std::move(parameters))
+        c_name_(std::move(name)),
+        calculator_(c_name_, std::move(parameters))
     {}
 
     /// Get the name of this calculator
     std::string name() const {
         return calculator_.name();
+    }
+
+    /// Get the name used to register this calculator
+    std::string c_name() const {
+        return c_name_;
     }
 
     /// Get the parameters of this calculator
@@ -100,6 +106,7 @@ public:
     );
 
 private:
+    std::string c_name_;
     rascaline::Calculator calculator_;
 };
 

--- a/rascaline-torch/src/register.cpp
+++ b/rascaline-torch/src/register.cpp
@@ -52,13 +52,13 @@ TORCH_LIBRARY(rascaline, module) {
         })
         .def_pickle(
             // __getstate__
-            [](const TorchCalculator& self) -> std::vector<std::string> {
-                return {self->name(), self->parameters()};
+            [](const TorchCalculator& self) -> std::tuple<std::string, std::string> {
+                return {self->c_name(), self->parameters()};
             },
             // __setstate__
-            [](std::vector<std::string> state) -> TorchCalculator {
+            [](std::tuple<std::string, std::string> state) -> TorchCalculator {
                 return c10::make_intrusive<CalculatorHolder>(
-                    state[0], state[1]
+                    std::get<0>(state), std::get<1>(state)
                 );
             })
         ;


### PR DESCRIPTION
We need to store the registration name, not the self-reported calculator name

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--254.org.readthedocs.build/en/254/

<!-- readthedocs-preview rascaline end -->