### PR TITLE
Fixed double-counting of periopdic image pairs

### DIFF
--- a/python/rascaline/rascaline/systems/ase.py
+++ b/python/rascaline/rascaline/systems/ase.py
@@ -91,10 +91,23 @@ class AseSystem(SystemBase):
 
         nl_result = neighborlist.neighbor_list("ijdDS", self._atoms, cutoff)
         for i, j, d, D, S in zip(*nl_result):
+            # we want a half neighbor list, so drop all duplicated neighbors
             if j < i:
-                # we want a half neighbor list, so drop all duplicated
-                # neighbors
                 continue
+            elif i == j:
+                if S[0] == 0 and S[1] == 0 and S[2] == 0:
+                    # only create pairs with the same atom twice if the pair spans more
+                    # than one unit cell
+                    continue
+                elif S[0] + S[1] + S[2] < 0 or (
+                    (S[0] + S[1] + S[2] == 0) and (S[2] < 0 or (S[2] == 0 and S[1] < 0))
+                ):
+                    # When creating pairs between an atom and one of its periodic
+                    # images, the code generate multiple redundant pairs (e.g. with
+                    # shifts 0 1 1 and 0 -1 -1); and we want to only keep one of these.
+                    # We keep the pair in the positive half plane of shifts.
+                    continue
+
             self._pairs.append((i, j, d, D, S))
 
         self._pairs_by_center = []

--- a/rascaline/src/calculators/soap/spherical_expansion.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion.rs
@@ -241,12 +241,6 @@ impl SphericalExpansion {
                 }
             }
 
-            if pair.first == pair.second {
-                // do not compute for the reversed pair if the pair is
-                // between an atom and its image
-                continue;
-            }
-
             if let Some(mapped_center) = result.centers_mapping[pair.second] {
                 // add the pair contribution to the atomic environnement
                 // corresponding to the **second** atom in the pair
@@ -778,7 +772,7 @@ mod tests {
 
     fn parameters() -> SphericalExpansionParameters {
         SphericalExpansionParameters {
-            cutoff: 3.5,
+            cutoff: 7.8,
             max_radial: 6,
             max_angular: 6,
             atomic_gaussian_width: 0.3,

--- a/rascaline/src/calculators/soap/spherical_expansion_pair.rs
+++ b/rascaline/src/calculators/soap/spherical_expansion_pair.rs
@@ -755,13 +755,7 @@ impl CalculatorBase for SphericalExpansionByPair {
                     }
                 }
 
-                // also check for the block with a reversed pair, except if
-                // we are handling a pair between an atom and it's own
-                // periodic image
-                if pair.first == pair.second {
-                    continue;
-                }
-
+                // also check for the block with a reversed pair
                 contribution.inverse_pair(&self.m_1_pow_l);
 
                 for spherical_harmonics_l in 0..=self.parameters.max_angular {
@@ -817,7 +811,7 @@ mod tests {
 
     fn parameters() -> SphericalExpansionParameters {
         SphericalExpansionParameters {
-            cutoff: 3.5,
+            cutoff: 7.3,
             max_radial: 6,
             max_angular: 6,
             atomic_gaussian_width: 0.3,


### PR DESCRIPTION
This was found by @liam-o-marsh in #240, and I cherry-picked it to merge the fix quicker. 

Ping @rosecers who wants to use this!

<!-- readthedocs-preview rascaline start -->
----
:books: Documentation preview :books:: https://rascaline--260.org.readthedocs.build/en/260/

<!-- readthedocs-preview rascaline end -->