### PR TITLE
fix broken metatensor documentation links

### DIFF
--- a/docs/src/explanations/concepts.rst
+++ b/docs/src/explanations/concepts.rst
@@ -67,7 +67,7 @@ After using a calculator on one or multiple systems, users will get the
 numerical representation of their atomic systems in a ``descriptor`` object.
 Rascaline uses `metatensor`_ ``TensorMap`` type when returning descriptors.
 
-.. _metatensor: https://lab-cosmo.github.io/metatensor/latest/
+.. _metatensor: https://lab-cosmo.github.io/metatensor/
 
 A ``TensorMap`` can be seen as a dictionary mapping some keys to a set of data
 blocks. Each block contains both data (and gradients) arrays — i.e.

--- a/python/rascaline/examples/compute-soap.py
+++ b/python/rascaline/examples/compute-soap.py
@@ -4,6 +4,7 @@ Computing SOAP features
 
 .. start-body
 """
+
 import chemfiles
 
 from rascaline import SoapPowerSpectrum

--- a/python/rascaline/examples/keys-selection.py
+++ b/python/rascaline/examples/keys-selection.py
@@ -4,6 +4,7 @@ Keys Selection
 
 .. start-body
 """
+
 import chemfiles
 import numpy as np
 from metatensor import Labels, TensorBlock, TensorMap

--- a/python/rascaline/examples/property-selection.py
+++ b/python/rascaline/examples/property-selection.py
@@ -4,6 +4,7 @@ Property Selection
 
 .. start-body
 """
+
 import chemfiles
 import numpy as np
 from metatensor import Labels, MetatensorError, TensorBlock, TensorMap

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_cg_cache.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_cg_cache.py
@@ -2,6 +2,7 @@
 Module that stores the ClebschGordanReal class for computing and caching Clebsch
 Gordan coefficients for use in CG combinations.
 """
+
 from typing import Union
 
 import numpy as np

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_clebsch_gordan.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_clebsch_gordan.py
@@ -3,6 +3,7 @@ Private module containing helper functions for public module
 :py:mod:`correlate_density` that compute Clebsch-gordan tensor products on
 metatensor :py:class:`TensorMap` objects.
 """
+
 import itertools
 from typing import List, Optional, Tuple, Union
 

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_dispatch.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_dispatch.py
@@ -1,6 +1,7 @@
 """
 Module containing dispatch functions for numpy/torch CG combination operations.
 """
+
 from typing import List, Optional
 
 import numpy as np

--- a/python/rascaline/rascaline/utils/clebsch_gordan/correlate_density.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/correlate_density.py
@@ -3,6 +3,7 @@ Module for computing Clebsch-gordan tensor product iterations on density (i.e.
 correlation order 1) tensors in TensorMap form, where the samples are
 equivalent.
 """
+
 from typing import List, Optional, Union
 
 from metatensor import Labels, TensorMap

--- a/python/rascaline/rascaline/utils/splines/atomic_density.py
+++ b/python/rascaline/rascaline/utils/splines/atomic_density.py
@@ -32,6 +32,7 @@ are provided, and you can implement your own by defining a new class.
     :show-inheritance:
 
 """
+
 from abc import ABC, abstractmethod
 from typing import Union
 

--- a/python/rascaline/tests/utils/rotations.py
+++ b/python/rascaline/tests/utils/rotations.py
@@ -2,6 +2,7 @@
 Class for generating real Wigner-D matrices, and using them to rotate ASE frames
 and TensorMaps of density coefficients in the spherical basis.
 """
+
 from typing import Sequence
 
 import pytest

--- a/python/rascaline/tests/utils/splines.py
+++ b/python/rascaline/tests/utils/splines.py
@@ -163,9 +163,7 @@ def test_kspace_radial_integral():
                 * sigma[n] ** (2 * i1)
             )
             coeffs_exact[n, ell] = (
-                factors[n, ell]
-                * kk**ell
-                * hyp1f1(i1, i2, -0.5 * (kk * sigma[n]) ** 2)
+                factors[n, ell] * kk**ell * hyp1f1(i1, i2, -0.5 * (kk * sigma[n]) ** 2)
             )
 
             coeffs_num[n, ell] = spliner.radial_integral(n, ell, kk)


### PR DESCRIPTION


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--275.org.readthedocs.build/en/275/

<!-- readthedocs-preview rascaline end -->