### PR TITLE
Fix "miscelaneous" typo

### DIFF
--- a/docs/src/references/api/c/misc.rst
+++ b/docs/src/references/api/c/misc.rst
@@ -1,5 +1,5 @@
-Miscelaneous
-============
+Miscellaneous
+=============
 
 Error handling
 --------------

--- a/docs/src/references/api/cxx/misc.rst
+++ b/docs/src/references/api/cxx/misc.rst
@@ -1,5 +1,5 @@
-Miscelaneous
-============
+Miscellaneous
+=============
 
 Logging should be handled using the :ref:`C API <c-api-logging>` functions.
 

--- a/docs/src/references/api/python/misc.rst
+++ b/docs/src/references/api/python/misc.rst
@@ -1,5 +1,5 @@
-Miscelaneous
-============
+Miscellaneous
+=============
 
 .. autoclass:: rascaline.RascalError
     :members:


### PR DESCRIPTION


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--276.org.readthedocs.build/en/276/

<!-- readthedocs-preview rascaline end -->