### PR TITLE
Use the input dtype and device for the output in rascaline-torch

### DIFF
--- a/rascaline-c-api/CMakeLists.txt
+++ b/rascaline-c-api/CMakeLists.txt
@@ -222,7 +222,7 @@ endif()
 # ============================================================================ #
 # Setup metatensor
 
-set(METATENSOR_FETCH_VERSION "0.1.1")
+set(METATENSOR_FETCH_VERSION "0.1.2")
 set(METATENSOR_REQUIRED_VERSION "0.1")
 if (RASCALINE_FETCH_METATENSOR)
     message(STATUS "Fetching metatensor @ ${METATENSOR_FETCH_VERSION} from github")
@@ -232,7 +232,7 @@ if (RASCALINE_FETCH_METATENSOR)
     FetchContent_Declare(
         metatensor
         URL      ${URL_ROOT}/metatensor-core-v${METATENSOR_FETCH_VERSION}/metatensor-core-cxx-${METATENSOR_FETCH_VERSION}.tar.gz
-        URL_HASH SHA256=54ae6dd087263f1315a6008ceb501a229823eb9a08d69abd2906c9e362b12f35
+        URL_HASH SHA256=d793a5f0c96ed79ba3fa944eb99cf72cbed2b76b7f90045db5855c219ecea843
     )
 
     if (CMAKE_VERSION VERSION_GREATER 3.18)

--- a/rascaline-torch/CMakeLists.txt
+++ b/rascaline-torch/CMakeLists.txt
@@ -58,7 +58,7 @@ find_package(Torch 1.11 REQUIRED)
 # ============================================================================ #
 # Setup metatensor_torch
 
-set(METATENSOR_FETCH_VERSION "0.2.0")
+set(METATENSOR_FETCH_VERSION "0.2.1")
 set(REQUIRED_METATENSOR_TORCH_VERSION "0.2")
 if (RASCALINE_TORCH_FETCH_METATENSOR_TORCH)
     message(STATUS "Fetching metatensor_torch @ ${METATENSOR_FETCH_VERSION} from github")
@@ -68,7 +68,7 @@ if (RASCALINE_TORCH_FETCH_METATENSOR_TORCH)
     FetchContent_Declare(
         metatensor_torch
         URL      ${URL_ROOT}/metatensor-torch-v${METATENSOR_FETCH_VERSION}/metatensor-torch-cxx-${METATENSOR_FETCH_VERSION}.tar.gz
-        URL_HASH SHA256=9561e210c07b8df9af462341193c234b4f39f5b0226cccfc63852d986885f949
+        URL_HASH SHA256=f4ecd15b4b2effbd461b6e890fadc20f06d9c18ea976c70dcfe72010f76155be
     )
 
     if (CMAKE_VERSION VERSION_GREATER 3.18)

--- a/rascaline-torch/src/system.cpp
+++ b/rascaline-torch/src/system.cpp
@@ -7,8 +7,8 @@ using namespace rascaline_torch;
 
 SystemAdapter::SystemAdapter(metatensor_torch::System system): system_(std::move(system)) {
     this->species_ = system_->species().to(torch::kCPU).contiguous();
-    this->positions_ = system_->positions().to(torch::kDouble).to(torch::kCPU).contiguous();
-    this->cell_ = system_->cell().to(torch::kDouble).to(torch::kCPU).contiguous();
+    this->positions_ = system_->positions().to(torch::kCPU).to(torch::kDouble).contiguous();
+    this->cell_ = system_->cell().to(torch::kCPU).to(torch::kDouble).contiguous();
 
     // convert all neighbors list that where requested by rascaline
     for (const auto& options: system_->known_neighbors_lists()) {
@@ -18,7 +18,7 @@ SystemAdapter::SystemAdapter(metatensor_torch::System system): system_(std::move
                 auto samples_values = neighbors->samples()->values().to(torch::kCPU).contiguous();
                 auto samples = samples_values.accessor<int32_t, 2>();
 
-                auto distances_tensor = neighbors->values().reshape({-1, 3}).to(torch::kCPU, torch::kDouble).contiguous();
+                auto distances_tensor = neighbors->values().reshape({-1, 3}).to(torch::kCPU).to(torch::kDouble).contiguous();
                 auto distances = distances_tensor.accessor<double, 2>();
 
                 auto n_pairs = samples.size(1);


### PR DESCRIPTION
All calculations still happen on CPU with 64-bit floats, but the data is automatically converted on input and output as required.

Should help with https://github.com/lab-cosmo/metatensor-models/pull/58

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--278.org.readthedocs.build/en/278/

<!-- readthedocs-preview rascaline end -->