### PR TITLE
Pin last rustc 1.65 version of ahash

### DIFF
--- a/rascaline/Cargo.toml
+++ b/rascaline/Cargo.toml
@@ -37,6 +37,9 @@ harness = false
 
 [dependencies]
 metatensor = {version = "0.1", features = ["rayon"]}
+# This is last version supporting rustc 1.65 used in metatensor.
+# Remove once new version of metatensor with pinned version is relased.
+ahash = "=0.8.7"
 
 ndarray = {version = "0.15", features = ["approx-0_5", "rayon", "serde"]}
 num-traits = "0.2"


### PR DESCRIPTION
`metatensor` uses `ahash` and the latest version of `ahash` requires rustc 1.72, which for now we don't want to enforce for now.

We pin the version here as well because otherwise need a metatensor-core release before this also has an effect here. 

See also https://github.com/lab-cosmo/metatensor/pull/505


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--280.org.readthedocs.build/en/280/

<!-- readthedocs-preview rascaline end -->