### PR TITLE
Print spline convergence information as `debug` instead of `info`

### DIFF
--- a/rascaline/src/math/splines.rs
+++ b/rascaline/src/math/splines.rs
@@ -1,5 +1,5 @@
 use ndarray::{Array, ArrayViewMut, azip};
-use log::info;
+use log::debug;
 
 use crate::Error;
 
@@ -168,7 +168,7 @@ impl<D: ndarray::Dimension> HermitCubicSpline<D> {
             mean_relative_error /= error_count as f64;
 
             if mean_absolute_error < accuracy || mean_relative_error < accuracy {
-                info!(
+                debug!(
                     "spline reached requested accuracy ({:.3e}) with {} reference points (max absolute error is {:.3e})",
                     accuracy, spline.len(), max_absolute_error,
                 );


### PR DESCRIPTION


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview rascaline end -->