### PR TITLE
Parallelize compilation with cmake

### DIFF
--- a/python/rascaline-torch/setup.py
+++ b/python/rascaline-torch/setup.py
@@ -106,6 +106,7 @@ class cmake_ext(build_ext):
                 "cmake",
                 "--build",
                 build_dir,
+                "--parallel",
                 "--config",
                 "Release",
                 "--target",

--- a/rascaline-c-api/tests/utils/mod.rs
+++ b/rascaline-c-api/tests/utils/mod.rs
@@ -37,6 +37,7 @@ pub fn cmake_build(build_dir: &Path) -> Command {
     cmake_build.current_dir(build_dir);
     cmake_build.arg("--build");
     cmake_build.arg(".");
+    cmake_build.arg("--parallel");
     cmake_build.arg("--config");
     cmake_build.arg(build_type());
 

--- a/setup.py
+++ b/setup.py
@@ -112,11 +112,11 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir],
+            ["cmake", "--build", build_dir, "--parallel"],
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--target", "install"],
+            ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -112,10 +112,6 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--parallel"],
-            check=True,
-        )
-        subprocess.run(
             ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )


### PR DESCRIPTION
We use cmake's `--parallel` flag to speed up compilation for Python builds

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--292.org.readthedocs.build/en/292/

<!-- readthedocs-preview rascaline end -->