### PR TITLE
temptative fix for the case where a calculator does not return anything

### DIFF
--- a/rascaline/src/calculator.rs
+++ b/rascaline/src/calculator.rs
@@ -294,6 +294,10 @@ impl Calculator {
     #[time_graph::instrument(name="Calculator::prepare")]
     fn prepare(&mut self, systems: &mut [Box<dyn System>], options: CalculationOptions) -> Result<TensorMap, Error> {
         let default_keys = self.implementation.keys(systems)?;
+        if default_keys.count() == 0 {
+            return Ok(TensorMap::new(default_keys, vec![])?)
+        }
+
         let keys = match options.selected_keys {
             Some(keys) if keys.is_empty() => {
                 return Err(Error::InvalidParameter("selected keys can not be empty".into()));

--- a/rascaline/src/calculator.rs
+++ b/rascaline/src/calculator.rs
@@ -56,7 +56,9 @@ impl<'a> LabelsSelection<'a> {
               G: FnOnce(&Labels) -> Result<Vec<Labels>, Error>,
               H: Fn(TensorBlockRef<'_>) -> Labels,
     {
-        assert_ne!(keys.count(), 0);
+        if keys.count() == 0 {
+            return Ok(vec![]);
+        }
 
         match *self {
             LabelsSelection::All => {
@@ -294,9 +296,6 @@ impl Calculator {
     #[time_graph::instrument(name="Calculator::prepare")]
     fn prepare(&mut self, systems: &mut [Box<dyn System>], options: CalculationOptions) -> Result<TensorMap, Error> {
         let default_keys = self.implementation.keys(systems)?;
-        if default_keys.count() == 0 {
-            return Ok(TensorMap::new(default_keys, vec![])?)
-        }
 
         let keys = match options.selected_keys {
             Some(keys) if keys.is_empty() => {

--- a/rascaline/src/calculators/neighbor_list.rs
+++ b/rascaline/src/calculators/neighbor_list.rs
@@ -938,4 +938,21 @@ mod tests {
         ));
 
     }
+    #[test]
+    fn check_empty_response() {
+        let mut calculator = Calculator::from(Box::new(NeighborList {
+            cutoff: 0.1,
+            full_neighbor_list: true,
+            self_pairs: false,
+        }) as Box<dyn CalculatorBase>);
+        let mut systems = test_systems(&["water"]);
+
+        let descriptor = calculator.compute(&mut systems, Default::default()).unwrap();
+
+        // cutoff too low, TensorMap is empty!
+        assert_eq!(descriptor.keys(), &Labels::new::<i32,2>(
+            ["first_atom_type", "second_atom_type"],
+            &[],
+        ));
+    }
 }


### PR DESCRIPTION
simple python test:
```python
import pyscf, rascaline
mol = rascaline.systems.wrap_system(pyscf.M(atom='H 0 0 -10; H 0 0 10'))
rascaline.calculators.NeighborList(5.0,False).compute(mol)
```

Since the cutoff is smaller than the distance between hydrogens, there are no pairs found by `compute_neighbors`, causing `assert_ne!(keys.count(), 0);` to panic (at `rascaline/src/calculator.rs:59:9`).

Those three lines prevent the panic by making `Calculator::prepare()` return an empty TensorMap early.


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--308.org.readthedocs.build/en/308/

<!-- readthedocs-preview rascaline end -->