### PR TITLE
Don't use macos-11 runners on CI, they are deprecated

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,11 +23,11 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             cibw_arch: x86_64
           - name: x86_64 macOS
-            os: macos-11
+            os: macos-13
             rust-target: x86_64-apple-darwin
             cibw_arch: x86_64
           - name: M1 macOS
-            os: macos-11
+            os: macos-14
             rust-target: aarch64-apple-darwin
             cibw_arch: arm64
           - name: x86_64 Windows

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
             python-version: "3.8"
           - os: ubuntu-22.04
             python-version: "3.12"
-          - os: macos-11
+          - os: macos-13
             python-version: "3.12"
           - os: windows-2019
             python-version: "3.12"

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -47,7 +47,7 @@ jobs:
             extra-name: / cmake 3.16
             working-directory: /__w/rascaline/rascaline
 
-          - os: macos-11
+          - os: macos-13
             rust-version: stable
             rust-target: x86_64-apple-darwin
             build-type: debug


### PR DESCRIPTION


<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--313.org.readthedocs.build/en/313/

<!-- readthedocs-preview rascaline end -->