### PR TITLE
Cartesian to spherical

### DIFF
--- a/docs/src/devdoc/how-to/new-calculator.rst
+++ b/docs/src/devdoc/how-to/new-calculator.rst
@@ -355,12 +355,12 @@ requested by the user.
 
 To find blocks and check for samples, we can use the `Labels::position`_
 function on the keys and the samples `Labels`_. This function returns an
-``Option<usize>``, which will be :py:obj:`None` is the label (key or sample)
-was not found, and ``Some(position)`` where ``position`` is an unsigned integer
-if the label was found. For the keys, we know the blocks must exists, so we
-again use ``expect`` to immediately extract the value of the block index and
-access the block. For the samples, we keep them as ``Option<usize>`` and will
-deal with missing samples later.
+``Option<usize>``, which will be ``None`` is the label (key or sample) was not
+found, and ``Some(position)`` where ``position`` is an unsigned integer if the
+label was found. For the keys, we know the blocks must exists, so we again use
+``expect`` to immediately extract the value of the block index and access the
+block. For the samples, we keep them as ``Option<usize>`` and will deal with
+missing samples later.
 
 One thing to keep in mind is that a given pair can participate to two different
 samples. If two atoms ``i`` and ``j`` are closer than the cutoff, the list of

--- a/docs/src/references/api/python/utils/clebsch-gordan.rst
+++ b/docs/src/references/api/python/utils/clebsch-gordan.rst
@@ -3,3 +3,8 @@ Clebsch-Gordan products
 
 .. autoclass:: rascaline.utils.DensityCorrelations
     :members:
+
+
+.. autofunction:: rascaline.utils.cartesian_to_spherical
+
+.. autofunction:: rascaline.utils.calculate_cg_coefficients

--- a/python/rascaline-torch/rascaline/torch/calculator_base.py
+++ b/python/rascaline-torch/rascaline/torch/calculator_base.py
@@ -113,16 +113,16 @@ class CalculatorModule(torch.nn.Module):
 
         :param systems: single system or list of systems on which to run the
             calculation. If any of the systems' ``positions`` or ``cell`` has
-            ``requires_grad`` set to :py:obj:`True`, then the corresponding gradients
-            are computed and registered as a custom node in the computational graph, to
+            ``requires_grad`` set to ``True``, then the corresponding gradients are
+            computed and registered as a custom node in the computational graph, to
             allow backward propagation of the gradients later.
 
         :param gradients: List of forward gradients to keep in the output. If this is
-            :py:obj:`None` or an empty list ``[]``, no gradients are kept in the output.
-            Some gradients might still be computed at runtime to allow for backward
+            ``None`` or an empty list ``[]``, no gradients are kept in the output. Some
+            gradients might still be computed at runtime to allow for backward
             propagation.
 
-        :param use_native_system: This can only be :py:obj:`True`, and is here for
+        :param use_native_system: This can only be ``True``, and is here for
             compatibility with the same parameter on
             :py:meth:`rascaline.calculators.CalculatorBase.compute`.
 

--- a/python/rascaline-torch/rascaline/torch/system.py
+++ b/python/rascaline-torch/rascaline/torch/system.py
@@ -39,14 +39,13 @@ def systems_to_torch(
         this function converts them all and returns a list of converted systems.
 
     :param positions_requires_grad: The value of ``requires_grad`` on the output
-        ``positions``. If :py:obj:`None`` and the positions of the input is already a
+        ``positions``. If ``None`` and the positions of the input is already a
         :py:class:`torch.Tensor`, ``requires_grad`` is kept the same. Otherwise it is
-        initialized to :py:obj:`False`.
+        initialized to ``False``.
 
     :param cell_requires_grad: The value of ``requires_grad`` on the output ``cell``. If
-        :py:obj:`None` and the positions of the input is already a
-        :py:class:`torch.Tensor`, ``requires_grad`` is kept the same. Otherwise it is
-        initialized to :py:obj:`False`.
+        ``None`` and the positions of the input is already a :py:class:`torch.Tensor`,
+        ``requires_grad`` is kept the same. Otherwise it is initialized to ``False``.
     """
 
     try:

--- a/python/rascaline-torch/rascaline/torch/utils.py
+++ b/python/rascaline-torch/rascaline/torch/utils.py
@@ -38,6 +38,7 @@ module.__dict__["TorchScriptClass"] = torch.ScriptClass
 module.__dict__["Array"] = torch.Tensor
 module.__dict__["CalculatorBase"] = CalculatorModule
 module.__dict__["IntoSystem"] = System
+module.__dict__["BACKEND_IS_METATENSOR_TORCH"] = True
 
 
 def is_labels(obj: Any):

--- a/python/rascaline-torch/tests/utils/cartesian_spherical.py
+++ b/python/rascaline-torch/tests/utils/cartesian_spherical.py
@@ -1,0 +1,98 @@
+import pytest
+import torch
+from metatensor.torch import Labels, TensorBlock, TensorMap
+
+from rascaline.torch.utils.clebsch_gordan import cartesian_to_spherical
+
+
+@pytest.fixture
+def cartesian():
+    # the first block is completely symmetric
+    values_1 = torch.rand(10, 4, 3, 3, 3, 2, dtype=torch.float64)
+    values_1[:, :, 0, 1, 0, :] = values_1[:, :, 0, 0, 1, :]
+    values_1[:, :, 1, 0, 0, :] = values_1[:, :, 0, 0, 1, :]
+
+    values_1[:, :, 0, 2, 0, :] = values_1[:, :, 0, 0, 2, :]
+    values_1[:, :, 2, 0, 0, :] = values_1[:, :, 0, 0, 2, :]
+
+    values_1[:, :, 1, 0, 1, :] = values_1[:, :, 0, 1, 1, :]
+    values_1[:, :, 1, 1, 0, :] = values_1[:, :, 0, 1, 1, :]
+
+    values_1[:, :, 2, 0, 2, :] = values_1[:, :, 0, 2, 2, :]
+    values_1[:, :, 2, 2, 0, :] = values_1[:, :, 0, 2, 2, :]
+
+    values_1[:, :, 2, 1, 2, :] = values_1[:, :, 2, 2, 1, :]
+    values_1[:, :, 1, 2, 2, :] = values_1[:, :, 2, 2, 1, :]
+
+    values_1[:, :, 1, 2, 1, :] = values_1[:, :, 1, 1, 2, :]
+    values_1[:, :, 2, 1, 1, :] = values_1[:, :, 1, 1, 2, :]
+
+    values_1[:, :, 0, 2, 1, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 2, 0, 1, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 1, 0, 2, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 1, 2, 0, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 2, 1, 0, :] = values_1[:, :, 0, 1, 2, :]
+
+    block_1 = TensorBlock(
+        values=values_1,
+        samples=Labels.range("s", 10),
+        components=[
+            Labels.range("other", 4),
+            Labels.range("xyz_1", 3),
+            Labels.range("xyz_2", 3),
+            Labels.range("xyz_3", 3),
+        ],
+        properties=Labels.range("p", 2),
+    )
+
+    # second block does not have any specific symmetry
+    block_2 = TensorBlock(
+        values=torch.rand(12, 6, 3, 3, 3, 7, dtype=torch.float64),
+        samples=Labels.range("s", 12),
+        components=[
+            Labels.range("other", 6),
+            Labels.range("xyz_1", 3),
+            Labels.range("xyz_2", 3),
+            Labels.range("xyz_3", 3),
+        ],
+        properties=Labels.range("p", 7),
+    )
+
+    return TensorMap(Labels.range("key", 2), [block_1, block_2])
+
+
+def test_torch_script():
+    torch.jit.script(cartesian_to_spherical)
+
+
+def test_cartesian_to_spherical(cartesian):
+    # rank 1
+    spherical = cartesian_to_spherical(cartesian, components=["xyz_1"])
+
+    assert spherical.component_names == ["other", "o3_mu", "xyz_2", "xyz_3"]
+    assert spherical.keys.names == ["o3_lambda", "o3_sigma", "key"]
+    assert len(spherical.keys) == 2
+
+    # rank 2
+    spherical = cartesian_to_spherical(cartesian, components=["xyz_1", "xyz_2"])
+
+    assert spherical.component_names == ["other", "o3_mu", "xyz_3"]
+    assert spherical.keys.names == ["o3_lambda", "o3_sigma", "key"]
+    assert len(spherical.keys) == 5
+
+    # rank 3
+    spherical = cartesian_to_spherical(
+        cartesian, components=["xyz_1", "xyz_2", "xyz_3"]
+    )
+
+    assert spherical.component_names == ["other", "o3_mu"]
+    assert spherical.keys.names == [
+        "o3_lambda",
+        "o3_sigma",
+        "l_3",
+        "k_1",
+        "l_2",
+        "l_1",
+        "key",
+    ]
+    assert len(spherical.keys) == 10

--- a/python/rascaline/rascaline/calculator_base.py
+++ b/python/rascaline/rascaline/calculator_base.py
@@ -202,14 +202,14 @@ class CalculatorBase:
             systems are supported, see the documentation of
             :py:class:`rascaline.IntoSystem` to get the full list.
 
-        :param use_native_system: If :py:obj:`True` (this is the default), copy data
-            from the ``systems`` into Rust ``SimpleSystem``. This can be a lot faster
-            than having to cross the FFI boundary often when accessing the neighbor
-            list. Otherwise the Python neighbor list is used.
+        :param use_native_system: If ``True`` (this is the default), copy data from the
+            ``systems`` into Rust ``SimpleSystem``. This can be a lot faster than having
+            to cross the FFI boundary often when accessing the neighbor list. Otherwise
+            the Python neighbor list is used.
 
-        :param gradients: List of gradients to compute. If this is :py:obj:`None` or an
-            empty list ``[]``, no gradients are computed. Gradients are stored inside
-            the different blocks, and can be accessed with
+        :param gradients: List of gradients to compute. If this is ``None`` or an empty
+            list ``[]``, no gradients are computed. Gradients are stored inside the
+            different blocks, and can be accessed with
             ``descriptor.block(...).gradient(<parameter>)``, where ``<parameter>`` is a
             string describing the gradients. The following gradients are available:
 
@@ -258,8 +258,8 @@ class CalculatorBase:
                        {\partial \mathbf{H}} \right |_\mathbf{r}
 
         :param selected_samples: Set of samples on which to run the calculation. Use
-            :py:obj:`None` to run the calculation on all samples in the ``systems``
-            (this is the default).
+            ``None`` to run the calculation on all samples in the ``systems`` (this is
+            the default).
 
             If ``selected_samples`` is an :py:class:`metatensor.TensorMap`, then the
             samples for each key will be used as-is when computing the representation.
@@ -274,8 +274,8 @@ class CalculatorBase:
             from the default set with the same values for these variables as one of the
             entries in ``selected_samples`` will be used.
 
-        :param selected_properties: Set of properties to compute. Use :py:obj:`None` to
-            run the calculation on all properties (this is the default).
+        :param selected_properties: Set of properties to compute. Use ``None`` to run
+            the calculation on all properties (this is the default).
 
             If ``selected_properties`` is an :py:class:`metatensor.TensorMap`, then the
             properties for each key will be used as-is when computing the
@@ -292,9 +292,9 @@ class CalculatorBase:
             variables as one of the entries in ``selected_properties`` will be used.
 
         :param selected_keys: Selection for the keys to include in the output. If this
-            is :py:obj:`None`, the default set of keys (as determined by the calculator)
-            will be used. Note that this default set of keys can depend on which systems
-            we are running the calculation on.
+            is ``None``, the default set of keys (as determined by the calculator) will
+            be used. Note that this default set of keys can depend on which systems we
+            are running the calculation on.
         """
 
         c_systems = _convert_systems(systems)

--- a/python/rascaline/rascaline/utils/__init__.py
+++ b/python/rascaline/rascaline/utils/__init__.py
@@ -1,6 +1,10 @@
 import os
 
-from .clebsch_gordan import DensityCorrelations  # noqa
+from .clebsch_gordan import (  # noqa
+    DensityCorrelations,
+    calculate_cg_coefficients,
+    cartesian_to_spherical,
+)
 from .power_spectrum import PowerSpectrum  # noqa
 from .splines import (  # noqa
     AtomicDensityBase,

--- a/python/rascaline/rascaline/utils/_backend.py
+++ b/python/rascaline/rascaline/utils/_backend.py
@@ -39,6 +39,8 @@ except ImportError:
 
 Array = Union[np.ndarray, TorchTensor]
 
+BACKEND_IS_METATENSOR_TORCH = False
+
 __all__ = [
     "Array",
     "CalculatorBase",
@@ -53,4 +55,5 @@ __all__ = [
     "torch_jit_is_scripting",
     "torch_jit_export",
     "is_labels",
+    "BACKEND_IS_METATENSOR_TORCH",
 ]

--- a/python/rascaline/rascaline/utils/_dispatch.py
+++ b/python/rascaline/rascaline/utils/_dispatch.py
@@ -63,12 +63,11 @@ def concatenate(arrays: List[TorchTensor], axis: int):
 
 def empty_like(array, shape: Optional[List[int]] = None, requires_grad: bool = False):
     """
-    Create an uninitialized array, with the given ``shape``, and similar dtype,
-    device and other options as ``array``.
+    Create an uninitialized array, with the given ``shape``, and similar dtype, device
+    and other options as ``array``.
 
-    If ``shape`` is :py:obj:`None`, the array shape is used instead.
-    ``requires_grad`` is only used for torch tensors, and set the corresponding
-    value on the returned array.
+    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad`` is only
+    used for torch tensors, and set the corresponding value on the returned array.
 
     This is the equivalent to ``np.empty_like(array, shape=shape)``.
     """
@@ -143,12 +142,11 @@ def unique(array, axis: Optional[int] = None):
 
 def zeros_like(array, shape: Optional[List[int]] = None, requires_grad: bool = False):
     """
-    Create an array filled with zeros, with the given ``shape``, and similar
-    dtype, device and other options as ``array``.
+    Create an array filled with zeros, with the given ``shape``, and similar dtype,
+    device and other options as ``array``.
 
-    If ``shape`` is :py:obj:`None`, the array shape is used instead.
-    ``requires_grad`` is only used for torch tensors, and set the corresponding
-    value on the returned array.
+    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad`` is only
+    used for torch tensors, and set the corresponding value on the returned array.
 
     This is the equivalent to ``np.zeros_like(array, shape=shape)``.
     """

--- a/python/rascaline/rascaline/utils/_dispatch.py
+++ b/python/rascaline/rascaline/utils/_dispatch.py
@@ -437,12 +437,25 @@ def imag(array):
     """
     Takes the imag part of the array
 
-    This function has the same behavior as
-    ``np.imag(array)`` or ``torch.imag(array)``.
+    This function has the same behavior as ``np.imag(array)`` or ``torch.imag(array)``.
     """
     if isinstance(array, TorchTensor):
         return torch.imag(array)
     elif isinstance(array, np.ndarray):
         return np.imag(array)
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
+
+
+def roll(array, shifts: List[int], axis: List[int]):
+    """
+    Roll array elements along a given axis.
+
+    This function has the same behavior as ``np.roll(array)`` or ``torch.roll(array)``.
+    """
+    if isinstance(array, TorchTensor):
+        return torch.roll(array, shifts=shifts, dims=axis)
+    elif isinstance(array, np.ndarray):
+        return np.roll(array, shift=shifts, axis=axis)
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)

--- a/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
@@ -1,1 +1,3 @@
+from ._cartesian_spherical import cartesian_to_spherical  # noqa: F401
+from ._coefficients import calculate_cg_coefficients  # noqa: F401
 from ._correlate_density import DensityCorrelations  # noqa: F401

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_cartesian_spherical.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_cartesian_spherical.py
@@ -1,0 +1,440 @@
+"""
+This module contains utilities to convert cartesian TensorMap to spherical and
+respectively.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+
+from .. import _dispatch
+from .._backend import (
+    Array,
+    Labels,
+    TensorBlock,
+    TensorMap,
+    TorchTensor,
+    torch_jit_is_scripting,
+)
+from . import _coefficients
+
+
+def cartesian_to_spherical(
+    tensor: TensorMap,
+    components: List[str],
+    keep_l_in_keys: Optional[bool] = None,
+    remove_blocks_threshold: Optional[float] = 1e-9,
+    cg_backend: Optional[str] = None,
+    cg_coefficients: Optional[TensorMap] = None,
+) -> TensorMap:
+    """
+    Transform a ``tensor`` of arbitrary rank from cartesian form to a spherical form.
+
+    Starting from a tensor on a basis of product of cartesian coordinates, this function
+    computes the same tensor using a basis of spherical harmonics ``Y^M_L``. For
+    example, a rank 1 tensor with a single "xyz" component would be represented as a
+    single L=1 spherical harmonic; while a rank 5 tensor using a product basis ``ℝ^3 ⊗
+    ℝ^3 ⊗ ℝ^3 ⊗ ℝ^3 ⊗ ℝ^3`` would require multiple blocks up to L=5 spherical harmonics.
+
+    A single :py:class:`TensorBlock` in the input might correspond to multiple
+    :py:class:`TensorBlock` in the output. The output keys will contain all the
+    dimensions of the input keys, plus ``o3_lambda`` (indicating the spherical harmonics
+    degree) and ``o3_sigma`` (indicating that this block is a proper- or improper tensor
+    with ``+1`` and ``-1`` respectively). If ``keep_l_in_keys`` is ``True`` or if the
+    input tensor is a tensor of rank 3 or more, the keys will also contain multiple
+    ``l_{i}`` and  ``k_{i}`` dimensions, which indicate which angular momenta have been
+    coupled together in which order to get this block.
+
+    ``components`` specifies which ones of the components of the input
+    :py:class:`TensorMap` should be transformed from cartesian to spherical. All these
+    components will be replaced in the output by a single ``o3_mu`` component,
+    corresponding to the spherical harmonics ``M``.
+
+    By default, symmetric tensors will only contain blocks corresponding to
+    ``o3_sigma=1``. This is achieved by checking the norm of the blocks after the full
+    calculation; and dropping any block with a norm below ``remove_blocks_epsilon``. To
+    keep all blocks regardless of their norm, you can set
+    ``remove_blocks_epsilon=None``.
+
+    :param tensor: input tensor, using a cartesian product basis
+    :param components: components of the input tensor to transform into spherical
+        components
+    :param keep_l_in_keys: should the output contains the values of angular momenta that
+        where combined together? This defaults to ``False`` for rank 1 and 2 tensors,
+        and ``True`` for all other tensors.
+
+        Keys named ``l_{i}`` correspond to the input ``components``, with ``l_1`` being
+        the last entry in ``components`` and ``l_N`` the first one. Keys named ``k_{i}``
+        correspond to intermediary spherical components created during the calculation,
+        i.e. a ``k_{i}`` used to be ``o3_lambda``.
+    :param remove_blocks_threshold: Numerical tolerance to use when determining if a
+        block's norm is zero or not. Blocks with zero norm will be excluded from the
+        output. Set this to ``None`` to keep all blocks in the output.
+    :param cg_backend: Backend to use for Clebsch-Gordan calculations. This can be
+        ``"python-dense"`` or ``"python-sparse"`` for dense or sparse operations
+        respectively. If ``None``, this is automatically determined.
+    :param cg_coefficients: Cache containing Clebsch-Gordan coefficients. This is
+        optional except when using this function from TorchScript. The coefficients
+        should be computed with :py:func:`calculate_cg_coefficients`, using the same
+        ``cg_backend`` as this function.
+
+    :return: :py:class:`TensorMap` containing spherical components instead of cartesian
+        components.
+    """
+    if len(tensor) == 0 or len(components) == 0:
+        # nothing to do
+        return tensor
+
+    if not isinstance(components, list):
+        raise TypeError(f"`components` should be a list, got {type(components)}")
+
+    if keep_l_in_keys is None:
+        if len(components) < 3:
+            keep_l_in_keys = False
+        else:
+            keep_l_in_keys = True
+
+    axes_to_convert: List[int] = []
+    all_component_names = tensor.component_names
+    for component in components:
+        if component in all_component_names:
+            idx = all_component_names.index(component)
+            axes_to_convert.append(idx + 1)
+        else:
+            raise ValueError(f"'{component}' is not part of this tensor components")
+
+    for key, block in tensor.items():
+        for idx in axes_to_convert:
+            values_list = _dispatch.to_int_list(block.components[idx - 1].values[:, 0])
+            if values_list != [0, 1, 2]:
+                name = block.components[idx - 1].names[0]
+                raise ValueError(
+                    f"component '{name}' in block for {key.print()} should have "
+                    f"[0, 1, 2] as values, got {values_list} instead"
+                )
+
+    # we need components to be consecutive
+    if list(range(axes_to_convert[0], axes_to_convert[-1] + 1)) != axes_to_convert:
+        raise ValueError(
+            f"this function only supports consecutive components, {components} are not"
+        )
+
+    key_names = tensor.keys.names
+    if "o3_lambda" in key_names:
+        raise ValueError(
+            "this tensor already has an `o3_lambda` key, "
+            "is it already in spherical form?"
+        )
+
+    for i in range(len(components)):
+        if f"l_{i}" in key_names:
+            raise ValueError(
+                f"this tensor already has an `l_{i}` key, "
+                "is it already in spherical form?"
+            )
+
+    tensor_rank = len(components)
+    if tensor_rank > 2 and not keep_l_in_keys:
+        raise ValueError(
+            "`keep_l_in_keys` must be `True` for tensors of rank 3 and above"
+        )
+
+    if torch_jit_is_scripting():
+        use_torch = True
+    else:
+        if isinstance(tensor.block(0).values, TorchTensor):
+            use_torch = True
+        elif isinstance(tensor.block(0).values, np.ndarray):
+            use_torch = False
+        else:
+            raise TypeError(
+                f"unknown array type in tensor ({type(tensor.block(0).values)}), "
+                "only numpy and torch are supported"
+            )
+
+    if cg_backend is None:
+        # TODO: benchmark & change the default?
+        if use_torch:
+            cg_backend = "python-dense"
+        else:
+            cg_backend = "python-sparse"
+
+    new_component_names: List[str] = []
+    for idx in range(len(tensor.component_names)):
+        if idx + 1 in axes_to_convert:
+            if len(axes_to_convert) == 1:
+                new_component_names.append("o3_mu")
+            else:
+                new_component_names.append(f"__internal_to_convert_{idx}")
+        else:
+            new_component_names.append("")
+
+    # Step 1: transform xyz dimensions to o3_lambda=1 dimensions
+    # This is done with `roll`, since (y, z, x) is the same as m = (-1, 0, 1)
+    new_blocks: List[TensorBlock] = []
+    for block in tensor.blocks():
+        values = _dispatch.roll(
+            block.values,
+            shifts=[-1] * len(axes_to_convert),
+            axis=axes_to_convert,
+        )
+
+        new_components: List[Labels] = []
+        for idx, component in enumerate(block.components):
+            if idx + 1 in axes_to_convert:
+                new_components.append(
+                    Labels(
+                        names=[new_component_names[idx]],
+                        values=_dispatch.int_array_like(
+                            [[-1], [0], [1]], component.values
+                        ),
+                    )
+                )
+            else:
+                new_components.append(component)
+
+        new_blocks.append(
+            TensorBlock(values, block.samples, new_components, block.properties)
+        )
+
+    if tensor_rank == 1:
+        new_keys = tensor.keys
+        # we are done, add o3_lambda/o3_sigma/l_1 to the keys & return
+        if keep_l_in_keys:
+            new_keys = new_keys.insert(
+                0,
+                "l_1",
+                _dispatch.int_array_like([1] * len(new_keys), new_keys.values),
+            )
+
+        new_keys = new_keys.insert(
+            0,
+            "o3_sigma",
+            _dispatch.int_array_like([1] * len(tensor.keys), tensor.keys.values),
+        )
+
+        new_keys = new_keys.insert(
+            0,
+            "o3_lambda",
+            _dispatch.int_array_like([1] * len(tensor.keys), tensor.keys.values),
+        )
+
+        return TensorMap(new_keys, new_blocks)
+
+    # Step 2: if there is more than one dimension, couple them with CG coefficients
+    #
+    # We start from an array of shape [..., 3, 3, 3, 3, 3, ...] with as many 3 as
+    # `len(components)`. Then we iteratively combine the two rightmost components into
+    # as many new lambda/mu entries as required, until there is only one component left.
+    # Each step will create multiple blocks (corresponding to the different o3_lambda
+    # created by combining two o3_lambda=1 terms), that might on their turn create more
+    # blocks if more combinations are required.
+    #
+    # For example, with a rank 3 tensor we go through the following:
+    #
+    # - Step 1: [..., 3, 3, 3, ...] => [..., 3, 1, ...] (o3_lambda=0, o3_sigma=+1)
+    #                               => [..., 3, 3, ...] (o3_lambda=1, o3_sigma=-1)
+    #                               => [..., 3, 5, ...] (o3_lambda=2, o3_sigma=+1)
+    #
+    # - Step 2: [..., 3, 1, ...] => [..., 3, ...] (o3_lambda=1, o3_sigma=+1)
+    #           [..., 3, 3, ...] => [..., 1, ...] (o3_lambda=0, o3_sigma=-1)
+    #                            => [..., 3, ...] (o3_lambda=1, o3_sigma=+1)
+    #                            => [..., 5, ...] (o3_lambda=2, o3_sigma=-1)
+    #           [..., 3, 5, ...] => [..., 3, ...] (o3_lambda=1, o3_sigma=+1)
+    #                            => [..., 5, ...] (o3_lambda=2, o3_sigma=-1)
+    #                            => [..., 7, ...] (o3_lambda=3, o3_sigma=+1)
+    if cg_coefficients is None:
+        if torch_jit_is_scripting():
+            raise ValueError(
+                "in TorchScript mode, `cg_coefficients` must be pre-computed "
+                "and given to this function explicitly"
+            )
+        else:
+            cg_coefficients = _coefficients.calculate_cg_coefficients(
+                lambda_max=len(axes_to_convert),
+                cg_backend=cg_backend,
+                use_torch=use_torch,
+            )
+
+    iteration_index = 0
+    while len(axes_to_convert) > 1:
+        tensor = _do_coupling(
+            tensor=tensor,
+            component_1=axes_to_convert[-2] - 1,
+            component_2=axes_to_convert[-1] - 1,
+            cg_coefficients=cg_coefficients,
+            cg_backend=cg_backend,
+            keep_l_in_keys=keep_l_in_keys,
+            iteration_index=iteration_index,
+        )
+
+        axes_to_convert.pop()
+        iteration_index += 1
+
+    if remove_blocks_threshold is None:
+        return tensor
+
+    # Step 3: for symmetry reasons, some of the blocks will be zero everywhere (for
+    # example o3_sigma=-1 blocks if the input tensor is fully symmetric). If the user
+    # gave us a threshold, we remove all blocks with a norm below this threshold.
+    new_keys_values: List[Array] = []
+    new_blocks: List[TensorBlock] = []
+    for key_idx, block in enumerate(tensor.blocks()):
+        key = tensor.keys.entry(key_idx)
+        values = block.values.reshape(-1, 1)
+        norm = values.T @ values
+        if norm > remove_blocks_threshold:
+            new_keys_values.append(key.values.reshape(1, -1))
+            new_blocks.append(
+                TensorBlock(
+                    values=block.values,
+                    samples=block.samples,
+                    components=block.components,
+                    properties=block.properties,
+                )
+            )
+
+    return TensorMap(
+        Labels(tensor.keys.names, _dispatch.concatenate(new_keys_values, axis=0)),
+        new_blocks,
+    )
+
+
+def _do_coupling(
+    tensor: TensorMap,
+    component_1: int,
+    component_2: int,
+    keep_l_in_keys: bool,
+    iteration_index: int,
+    cg_coefficients: TensorMap,
+    cg_backend: str,
+) -> TensorMap:
+    """
+    Go from an uncoupled product basis that behave like a product of spherical harmonics
+    to a coupled basis that behaves like a single spherical harmonic.
+
+    This function takes in a :py:class:`TensorMap` where two of the components
+    (indicated by ``component_1`` and ``component_2``) behave like spherical harmonics
+    ``Y^m1_l1`` and ``Y^m2_l2``, and project it onto a single spherical harmonic
+    ``Y^M_L``. This transformation uses the following relation:
+
+    ``|L M> = |l1 l2 L M> = \\sum_{m1 m2} <l1 m1 l2 m2|L M> |l1 m1> |l2 m2>``
+
+    where ``<l1 m1 l2 m2|L M>`` are Clebsch-Gordan coefficients.
+
+    The output will contain many blocks for each block in the input, matching all the
+    different ``L`` (called ``o3_lambda`` in the code) required to do a full projection.
+
+    This process can be iterated: a multi-dimensional array that is the product of many
+    ``Y^m_l`` can be turned into a set of multiple terms transforming as a single
+    ``Y^M_L``.
+
+    :param tensor: input :py:class:`TensorMap`
+    :param components_1: first component of the ``tensor`` behaving like spherical
+        harmonics
+    :param components_2: second component of the ``tensor`` behaving like spherical
+        harmonics
+    :param keep_l_in_keys: whether ``l1`` and ``l2`` (the original spherical harmonic
+        degrees) should be kept in the keys. This can be useful to undo this
+        transformation (or even required if there is more than one path to get to a
+        given value for ``o3_lambda``)
+    :param iteration_index: when iterating the coupling, this should be the number of
+        iterations already done (i.e. the number of time this function has been called)
+    :param cg_coefficients: pre-computed set of Clebsch-Gordan coefficients
+    :param cg_backend: which backend to use for the calculations
+
+    :return: :py:class:`TensorMap` using the coupled basis. This will contain the same
+        keys as the input ``tensor``, plus ``o3_lambda``. The components in positions
+        ``components_1`` and ``components_2`` will be replaced by a single ``o3_mu``
+        component.
+    """
+    assert component_2 == component_1 + 1
+
+    new_keys = tensor.keys
+
+    if "o3_lambda" in tensor.keys.names:
+        old_sigmas = new_keys.column("o3_sigma")
+        new_keys = new_keys.remove("o3_sigma")
+    else:
+        old_sigmas = _dispatch.int_array_like([1] * len(new_keys), new_keys.values)
+
+    if keep_l_in_keys:
+        array_of_ones = _dispatch.int_array_like([1] * len(new_keys), new_keys.values)
+        if "o3_lambda" in tensor.keys.names:
+            assert iteration_index > 0
+            new_keys = new_keys.rename("o3_lambda", f"k_{iteration_index}")
+            new_keys = new_keys.insert(0, f"l_{iteration_index + 2}", array_of_ones)
+        else:
+            assert iteration_index == 0
+            new_keys = new_keys.insert(0, "l_1", array_of_ones)
+            new_keys = new_keys.insert(0, "l_2", array_of_ones)
+
+    new_keys_values: List[List[int]] = []
+    new_blocks: List[TensorBlock] = []
+    for key_idx, block in enumerate(tensor.blocks()):
+        key = new_keys.entry(key_idx)
+        old_sigma = int(old_sigmas[key_idx])
+
+        # get l1, l2 from the block's shape
+        block_shape = block.values.shape
+        l1 = (block_shape[component_1 + 1] - 1) // 2
+        l2 = (block_shape[component_2 + 1] - 1) // 2
+
+        # reshape the values to look like (n_s, 2*l1 + 1, 2*l2 + 1, n_p)
+        shape_before = 1
+        for axis in range(component_1 + 1):
+            shape_before *= block_shape[axis]
+
+        shape_after = 1
+        for axis in range(component_2 + 2, len(block_shape)):
+            shape_after *= block_shape[axis]
+
+        array = block.values.reshape(
+            shape_before,
+            block.values.shape[component_1 + 1],
+            block.values.shape[component_2 + 1],
+            shape_after,
+        )
+
+        # generate the set of o3_lambda to compute
+        o3_lambdas = list(range(max(l1, l2) - min(l1, l2), (l1 + l2) + 1))
+
+        # actual calculation
+        outputs = _coefficients.cg_couple(
+            array, o3_lambdas, cg_coefficients, cg_backend
+        )
+
+        # create one block for each output of `cg_couple`
+        for o3_lambda, values in zip(o3_lambdas, outputs):
+            o3_sigma = int(old_sigma * (-1) ** (l1 + l2 + o3_lambda))
+            new_keys_values.append(
+                [o3_lambda, o3_sigma] + _dispatch.to_int_list(key.values)
+            )
+
+            new_shape = list(block.values.shape)
+            new_shape.pop(component_2 + 1)
+            new_shape[component_1 + 1] = 2 * o3_lambda + 1
+
+            new_components = block.components
+            new_components.pop(component_2)
+            new_components[component_1] = Labels(
+                "o3_mu",
+                _dispatch.int_array_like(
+                    [[mu] for mu in range(-o3_lambda, o3_lambda + 1)], new_keys.values
+                ),
+            )
+
+            new_blocks.append(
+                TensorBlock(
+                    values.reshape(new_shape),
+                    samples=block.samples,
+                    components=new_components,
+                    properties=block.properties,
+                )
+            )
+
+    new_keys = Labels(
+        ["o3_lambda", "o3_sigma"] + new_keys.names,
+        _dispatch.int_array_like(new_keys_values, new_keys.values),
+    )
+    return TensorMap(new_keys, new_blocks)

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
@@ -152,7 +152,7 @@ class DensityCorrelations(TorchModule):
         self._max_angular = max_angular
         self._cg_coefficients = _coefficients.calculate_cg_coefficients(
             lambda_max=self._max_angular,
-            sparse=self._cg_backend == "python-sparse",
+            cg_backend=self._cg_backend,
             use_torch=(arrays_backend == "torch"),
         )
 

--- a/python/rascaline/rascaline/utils/power_spectrum.py
+++ b/python/rascaline/rascaline/utils/power_spectrum.py
@@ -42,11 +42,10 @@ class PowerSpectrum(TorchModule):
 
     :param calculator_1: first calculator
     :param calculator_1: second calculator
-    :param types: List of ``"neighbor_type"`` to use in the properties of the
-        output. This option might be useful when running the calculation on subset of a
-        whole dataset and trying to join along the ``sample`` dimension after the
-        calculation. If :py:obj:`None` blocks are filled with ``"neighbor_type"``
-        found in the systems.
+    :param types: List of ``"neighbor_type"`` to use in the properties of the output.
+        This option might be useful when running the calculation on subset of a whole
+        dataset and trying to join along the ``sample`` dimension after the calculation.
+        If ``None``, blocks are filled with ``"neighbor_type"`` found in the systems.
     :raises ValueError: If other calculators than
         :py:class:`rascaline.SphericalExpansion` or
         :py:class:`rascaline.LodeSphericalExpansion` are used.

--- a/python/rascaline/rascaline/utils/splines/splines.py
+++ b/python/rascaline/rascaline/utils/splines/splines.py
@@ -371,9 +371,9 @@ class RadialIntegralFromFunction(RadialIntegralSplinerBase):
     :parameter max_radial: number of angular components
     :parameter max_angular: number of radial components
     :parameter radial_integral_derivative: The derivative of the radial integral taking
-        the same parameters as ``radial_integral``. If it is :py:obj:`None` (default),
-        finite differences are used to calculate the derivative of the radial integral.
-        It is recommended to provide this parameter if possible. Derivatives from finite
+        the same parameters as ``radial_integral``. If it is ``None`` (default), finite
+        differences are used to calculate the derivative of the radial integral. It is
+        recommended to provide this parameter if possible. Derivatives from finite
         differences can cause problems when evaluating at the edges of the domain (i.e.,
         at ``0`` and ``spline_cutoff``) because the function might not be defined
         outside of the domain.

--- a/python/rascaline/tests/utils/cartesian_spherical.py
+++ b/python/rascaline/tests/utils/cartesian_spherical.py
@@ -1,0 +1,200 @@
+import numpy as np
+import pytest
+from metatensor import Labels, TensorBlock, TensorMap
+
+from rascaline.utils.clebsch_gordan import cartesian_to_spherical
+
+
+@pytest.fixture
+def cartesian():
+    # the first block is completely symmetric
+    values_1 = np.random.rand(10, 4, 3, 3, 3, 2)
+    values_1[:, :, 0, 1, 0, :] = values_1[:, :, 0, 0, 1, :]
+    values_1[:, :, 1, 0, 0, :] = values_1[:, :, 0, 0, 1, :]
+
+    values_1[:, :, 0, 2, 0, :] = values_1[:, :, 0, 0, 2, :]
+    values_1[:, :, 2, 0, 0, :] = values_1[:, :, 0, 0, 2, :]
+
+    values_1[:, :, 1, 0, 1, :] = values_1[:, :, 0, 1, 1, :]
+    values_1[:, :, 1, 1, 0, :] = values_1[:, :, 0, 1, 1, :]
+
+    values_1[:, :, 2, 0, 2, :] = values_1[:, :, 0, 2, 2, :]
+    values_1[:, :, 2, 2, 0, :] = values_1[:, :, 0, 2, 2, :]
+
+    values_1[:, :, 2, 1, 2, :] = values_1[:, :, 2, 2, 1, :]
+    values_1[:, :, 1, 2, 2, :] = values_1[:, :, 2, 2, 1, :]
+
+    values_1[:, :, 1, 2, 1, :] = values_1[:, :, 1, 1, 2, :]
+    values_1[:, :, 2, 1, 1, :] = values_1[:, :, 1, 1, 2, :]
+
+    values_1[:, :, 0, 2, 1, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 2, 0, 1, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 1, 0, 2, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 1, 2, 0, :] = values_1[:, :, 0, 1, 2, :]
+    values_1[:, :, 2, 1, 0, :] = values_1[:, :, 0, 1, 2, :]
+
+    block_1 = TensorBlock(
+        values=values_1,
+        samples=Labels.range("s", 10),
+        components=[
+            Labels.range("other", 4),
+            Labels.range("xyz_1", 3),
+            Labels.range("xyz_2", 3),
+            Labels.range("xyz_3", 3),
+        ],
+        properties=Labels.range("p", 2),
+    )
+
+    # second block does not have any specific symmetry
+    block_2 = TensorBlock(
+        values=np.random.rand(12, 6, 3, 3, 3, 7),
+        samples=Labels.range("s", 12),
+        components=[
+            Labels.range("other", 6),
+            Labels.range("xyz_1", 3),
+            Labels.range("xyz_2", 3),
+            Labels.range("xyz_3", 3),
+        ],
+        properties=Labels.range("p", 7),
+    )
+
+    return TensorMap(Labels.range("key", 2), [block_1, block_2])
+
+
+def test_cartesian_to_spherical_rank_1(cartesian):
+    spherical = cartesian_to_spherical(cartesian, components=["xyz_1"])
+
+    assert spherical.component_names == ["other", "o3_mu", "xyz_2", "xyz_3"]
+    assert spherical.keys.names == ["o3_lambda", "o3_sigma", "key"]
+
+    spherical = cartesian_to_spherical(
+        cartesian,
+        components=["xyz_1"],
+        keep_l_in_keys=True,
+    )
+    assert spherical.keys.names == ["o3_lambda", "o3_sigma", "l_1", "key"]
+
+
+def test_cartesian_to_spherical_rank_2(cartesian):
+    spherical = cartesian_to_spherical(cartesian, components=["xyz_1", "xyz_2"])
+
+    assert spherical.component_names == ["other", "o3_mu", "xyz_3"]
+    assert spherical.keys == Labels(
+        ["o3_lambda", "o3_sigma", "key"],
+        np.array(
+            [
+                # only o3_sigma=1 in the symmetric block
+                [0, 1, 0],
+                [2, 1, 0],
+                # all o3_sigma in the non-symmetric block
+                [0, 1, 1],
+                [1, -1, 1],
+                [2, 1, 1],
+            ]
+        ),
+    )
+
+    spherical = cartesian_to_spherical(
+        cartesian,
+        components=["xyz_1", "xyz_2"],
+        keep_l_in_keys=True,
+        remove_blocks_threshold=None,
+    )
+    assert spherical.keys.names == ["o3_lambda", "o3_sigma", "l_2", "l_1", "key"]
+    # all blocks are kept
+    assert len(spherical.keys) == 6
+
+
+def test_cartesian_to_spherical_rank_3(cartesian):
+    spherical = cartesian_to_spherical(
+        cartesian, components=["xyz_1", "xyz_2", "xyz_3"]
+    )
+
+    assert spherical.component_names == ["other", "o3_mu"]
+    assert spherical.keys == Labels(
+        ["o3_lambda", "o3_sigma", "l_3", "k_1", "l_2", "l_1", "key"],
+        np.array(
+            [
+                # only o3_sigma=1 for the symmetric block, but there are multiple "path"
+                # ("l_3", "k_1", "l_2", "l_1") that lead to o3_lambda=1
+                [1, 1, 1, 0, 1, 1, 0],
+                [1, 1, 1, 2, 1, 1, 0],
+                [3, 1, 1, 2, 1, 1, 0],
+                # all possible o3_sigma for the non-symmetric block
+                [1, 1, 1, 0, 1, 1, 1],
+                [0, -1, 1, 1, 1, 1, 1],
+                [1, 1, 1, 1, 1, 1, 1],
+                [2, -1, 1, 1, 1, 1, 1],
+                [1, 1, 1, 2, 1, 1, 1],
+                [2, -1, 1, 2, 1, 1, 1],
+                [3, 1, 1, 2, 1, 1, 1],
+            ]
+        ),
+    )
+
+    spherical = cartesian_to_spherical(
+        cartesian,
+        components=["xyz_1", "xyz_2", "xyz_3"],
+        remove_blocks_threshold=None,
+    )
+    # all blocks are kept, even those with norm=0
+    assert len(spherical.keys) == 14
+
+
+@pytest.mark.parametrize("cg_backend", ["python-dense", "python-sparse"])
+@pytest.mark.parametrize(
+    "components", [["xyz_1"], ["xyz_1", "xyz_12"], ["xyz_1", "xyz_2", "xyz_3"]]
+)
+def test_cartesian_to_spherical_and_back(cartesian, components, cg_backend):
+    spherical = cartesian_to_spherical(
+        cartesian,
+        components=["xyz_1", "xyz_2", "xyz_3"],
+        keep_l_in_keys=True,
+        cg_backend=cg_backend,
+    )
+
+    assert "o3_lambda" in spherical.keys.names
+    # TODO: check for identity after spherical_to_cartesian
+
+
+def test_cartesian_to_spherical_errors(cartesian):
+    message = "`components` should be a list, got <class 'str'>"
+    with pytest.raises(TypeError, match=message):
+        cartesian_to_spherical(cartesian, components="xyz_1")
+
+    message = "'1' is not part of this tensor components"
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(cartesian, components=[1, 2])
+
+    message = "'not_there' is not part of this tensor components"
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(cartesian, components=["not_there"])
+
+    message = (
+        "this function only supports consecutive components, "
+        "\\['xyz_2', 'xyz_1'\\] are not"
+    )
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(cartesian, components=["xyz_2", "xyz_1"])
+
+    message = (
+        "this function only supports consecutive components, "
+        "\\['xyz_1', 'xyz_3'\\] are not"
+    )
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(cartesian, components=["xyz_1", "xyz_3"])
+
+    message = (
+        "component 'other' in block for \\(key=0\\) should have \\[0, 1, 2\\] "
+        "as values, got \\[0, 1, 2, 3\\] instead"
+    )
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(cartesian, components=["other"])
+
+    message = "`keep_l_in_keys` must be `True` for tensors of rank 3 and above"
+    with pytest.raises(ValueError, match=message):
+        cartesian_to_spherical(
+            cartesian,
+            components=["xyz_1", "xyz_2", "xyz_3"],
+            keep_l_in_keys=False,
+        )

--- a/python/rascaline/tests/utils/correlate_density.py
+++ b/python/rascaline/tests/utils/correlate_density.py
@@ -376,7 +376,9 @@ def test_clebsch_gordan_orthogonality(l1, l2, arrays_backend):
     for details.
     """
     cg_coeffs = calculate_cg_coefficients(
-        lambda_max=5, sparse=False, use_torch=arrays_backend == "torch"
+        lambda_max=5,
+        cg_backend="python-dense",
+        use_torch=arrays_backend == "torch",
     )
 
     lam_min = abs(l1 - l2)

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,6 @@ deps =
     blackdoc
     flake8
     flake8-bugbear
-    flake8-sphinx-links
     isort
 
 commands =


### PR DESCRIPTION
This PR implements a function to transform a TensorMap from cartesian product basis to a spherical basis.


Still TBD:

- [ ] `spherical_to_cartesian`, the inverse of this function
- [ ] Some example using this function and DensityCorrelation to build a Lambda-SOAP model (maybe for a future PR)

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--315.org.readthedocs.build/en/315/

<!-- readthedocs-preview rascaline end -->