### PR TITLE
Implementation of `EquivariantPowerSpectrum` and `EquivariantPowerSpectrumByPair` convenience calculators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 
 dependencies = [
     "metatensor-core >=0.1.0,<0.2.0",
+    "metatensor-operations >=0.2.0,<0.3.0",
     "wigners",
 ]
 

--- a/python/rascaline-torch/rascaline/torch/utils.py
+++ b/python/rascaline-torch/rascaline/torch/utils.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any
 
 import torch
-from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
+from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap, operations
 
 import rascaline.utils
 
@@ -39,6 +39,7 @@ module.__dict__["Array"] = torch.Tensor
 module.__dict__["CalculatorBase"] = CalculatorModule
 module.__dict__["IntoSystem"] = System
 module.__dict__["BACKEND_IS_METATENSOR_TORCH"] = True
+module.__dict__["operations"] = operations
 
 
 def is_labels(obj: Any):

--- a/python/rascaline-torch/tests/utils/correlate_density.py
+++ b/python/rascaline-torch/tests/utils/correlate_density.py
@@ -66,6 +66,7 @@ def test_torch_script_correlate_density_angular_selection(
         body_order=body_order,
         angular_cutoff=None,
         selected_keys=selected_keys,
+        match_keys=["center_type"],
         skip_redundant=skip_redundant,
     )
 
@@ -87,6 +88,7 @@ def test_jit_save_load():
         max_angular=2,
         body_order=3,
         angular_cutoff=1,
+        match_keys=["center_type"],
     )
     scripted_correlate_density = torch.jit.script(corr_calculator)
     with io.BytesIO() as buffer:
@@ -104,6 +106,7 @@ def test_save_load():
         body_order=3,
         angular_cutoff=1,
         cg_backend="python-dense",
+        match_keys=["center_type"],
     )
     with io.BytesIO() as buffer:
         torch.save(corr_calculator, buffer)

--- a/python/rascaline-torch/tests/utils/correlate_density.py
+++ b/python/rascaline-torch/tests/utils/correlate_density.py
@@ -60,6 +60,7 @@ def test_torch_script_correlate_density_angular_selection(
     ``selected_keys``.
     """
     nu_1 = spherical_expansion()
+    nu_1 = nu_1.keys_to_properties("neighbor_type")
     body_order = 3
     corr_calculator = DensityCorrelations(
         max_angular=SPHERICAL_EXPANSION_HYPERS["max_angular"] * (body_order - 1),

--- a/python/rascaline-torch/tests/utils/correlate_density.py
+++ b/python/rascaline-torch/tests/utils/correlate_density.py
@@ -60,10 +60,10 @@ def test_torch_script_correlate_density_angular_selection(
     ``selected_keys``.
     """
     nu_1 = spherical_expansion()
-    correlation_order = 2
+    body_order = 3
     corr_calculator = DensityCorrelations(
-        max_angular=SPHERICAL_EXPANSION_HYPERS["max_angular"] * correlation_order,
-        correlation_order=correlation_order,
+        max_angular=SPHERICAL_EXPANSION_HYPERS["max_angular"] * (body_order - 1),
+        body_order=body_order,
         angular_cutoff=None,
         selected_keys=selected_keys,
         skip_redundant=skip_redundant,
@@ -85,7 +85,7 @@ def test_torch_script_correlate_density_angular_selection(
 def test_jit_save_load():
     corr_calculator = DensityCorrelations(
         max_angular=2,
-        correlation_order=2,
+        body_order=3,
         angular_cutoff=1,
     )
     scripted_correlate_density = torch.jit.script(corr_calculator)
@@ -101,7 +101,7 @@ def test_save_load():
     a non-contiguous CG cache."""
     corr_calculator = DensityCorrelations(
         max_angular=2,
-        correlation_order=2,
+        body_order=3,
         angular_cutoff=1,
         cg_backend="python-dense",
     )

--- a/python/rascaline/rascaline/utils/__init__.py
+++ b/python/rascaline/rascaline/utils/__init__.py
@@ -2,6 +2,7 @@ import os
 
 from .clebsch_gordan import (  # noqa
     DensityCorrelations,
+    CorrelateTensorWithDensity,
     calculate_cg_coefficients,
     cartesian_to_spherical,
 )

--- a/python/rascaline/rascaline/utils/_backend.py
+++ b/python/rascaline/rascaline/utils/_backend.py
@@ -4,7 +4,6 @@ import numpy as np
 from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap, operations
 
 from ..calculator_base import CalculatorBase
-from ..calculators import SphericalExpansion, SphericalExpansionByPair
 from ..systems import IntoSystem
 
 

--- a/python/rascaline/rascaline/utils/_backend.py
+++ b/python/rascaline/rascaline/utils/_backend.py
@@ -4,6 +4,7 @@ import numpy as np
 from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap, operations
 
 from ..calculator_base import CalculatorBase
+from ..calculators import SphericalExpansion, SphericalExpansionByPair
 from ..systems import IntoSystem
 
 

--- a/python/rascaline/rascaline/utils/_backend.py
+++ b/python/rascaline/rascaline/utils/_backend.py
@@ -1,7 +1,7 @@
 from typing import Any, Union
 
 import numpy as np
-from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap
+from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap, operations
 
 from ..calculator_base import CalculatorBase
 from ..systems import IntoSystem
@@ -56,4 +56,5 @@ __all__ = [
     "torch_jit_export",
     "is_labels",
     "BACKEND_IS_METATENSOR_TORCH",
+    "operations",
 ]

--- a/python/rascaline/rascaline/utils/_dispatch.py
+++ b/python/rascaline/rascaline/utils/_dispatch.py
@@ -59,6 +59,26 @@ def concatenate(arrays: List[TorchTensor], axis: int):
         return np.concatenate(arrays, axis)
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
+    
+def stack(arrays: List[TorchTensor], axis: int):
+    """
+    Stack a group of arrays along a new axis.
+
+    This function has the same behavior as ``numpy.stack(arrays, axis)``
+    and ``torch.stack(arrays, axis)``.
+
+    Passing `axis` as ``0`` is equivalent to stacking arrays along the first
+    dimension, ``1`` along the second dimension, and so on.
+    """
+    if isinstance(arrays[0], TorchTensor):
+        _check_all_torch_tensor(arrays)
+        return torch.stack(arrays, axis)
+    elif isinstance(arrays[0], np.ndarray):
+        _check_all_np_ndarray(arrays)
+        return np.stack(arrays, axis)
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
+
 
 
 def empty_like(array, shape: Optional[List[int]] = None, requires_grad: bool = False):

--- a/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
@@ -2,4 +2,4 @@ from ._cartesian_spherical import cartesian_to_spherical  # noqa: F401
 from ._coefficients import calculate_cg_coefficients  # noqa: F401
 from ._correlate_density import DensityCorrelations  # noqa: F401
 from ._correlate_tensors import CorrelateTensorWithDensity  # noqa: F401
-from ._lambda_soap import LambdaSoap, LambdaSoapXSphExByPair  # noqa: F401
+from ._lambda_soap import EquivariantPowerSpectrum, EquivariantPowerSpectrumByPair  # noqa: F401

--- a/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/__init__.py
@@ -1,3 +1,5 @@
 from ._cartesian_spherical import cartesian_to_spherical  # noqa: F401
 from ._coefficients import calculate_cg_coefficients  # noqa: F401
 from ._correlate_density import DensityCorrelations  # noqa: F401
+from ._correlate_tensors import CorrelateTensorWithDensity  # noqa: F401
+from ._lambda_soap import LambdaSoap, LambdaSoapXSphExByPair  # noqa: F401

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_cartesian_spherical.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_cartesian_spherical.py
@@ -60,7 +60,7 @@ def cartesian_to_spherical(
     :param components: components of the input tensor to transform into spherical
         components
     :param keep_l_in_keys: should the output contains the values of angular momenta that
-        where combined together? This defaults to ``False`` for rank 1 and 2 tensors,
+        were combined together? This defaults to ``False`` for rank 1 and 2 tensors,
         and ``True`` for all other tensors.
 
         Keys named ``l_{i}`` correspond to the input ``components``, with ``l_1`` being

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
@@ -6,7 +6,6 @@ equivalent.
 
 from typing import List, Optional, Union
 
-import metatensor as mts
 import numpy as np
 
 from .. import _dispatch
@@ -16,6 +15,7 @@ from .._backend import (
     TensorMap,
     TorchModule,
     TorchScriptClass,
+    operations,
     torch_jit_export,
     torch_jit_is_scripting,
 )
@@ -273,7 +273,7 @@ class DensityCorrelations(TorchModule):
         n_iterations = self._correlation_order - 1  # num iterations
 
         # Add "order_nu" to the keys metadata
-        density = mts.insert_dimension(density, "keys", 0, "order_nu", 1)
+        density = operations.insert_dimension(density, "keys", 0, "order_nu", 1)
         # density = _utils.standardize_keys(density)  # standardize metadata
 
         # Check metadata
@@ -305,7 +305,7 @@ class DensityCorrelations(TorchModule):
         # this point carry the property name suffix "_1", but the suffix of `density`
         # will be incremented in the iterative combination loop below.
         for name in density.property_names:
-            density = mts.rename_dimension(
+            density = operations.rename_dimension(
                 density,
                 "properties",
                 name,
@@ -377,7 +377,7 @@ class DensityCorrelations(TorchModule):
             # Increment the numeric suffix of the properties names of the nu=1 density
             # to "_{nu}", where nu is the current correlation order.
             for name in density.property_names:
-                density = mts.rename_dimension(
+                density = operations.rename_dimension(
                     density,
                     "properties",
                     name,

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
@@ -45,20 +45,20 @@ class DensityCorrelations(TorchModule):
     order passed in ``correlation_order``. By default only the last correlation (i.e.
     the correlation of order ``correlation_order``) is returned.
 
-    This function is an iterative special case of the more general
-    :py:func:`correlate_tensors`. As a density is being correlated with itself, some
-    redundant CG tensor products can be skipped with the ``skip_redundant`` keyword.
+    As a density is being correlated with itself, some redundant CG tensor products can
+    be skipped with the ``skip_redundant`` keyword.
 
-    Selections on the angular and parity channels at each iteration can also be
-    controlled with arguments ``angular_cutoff``, ``angular_selection`` and
-    ``parity_selection``.
+    Global selections on the maximum angular channel computed at each iteration can be
+    set with the ``angular_cutoff`` argument, while ``selected_keys`` allows control
+    over computation of specific combinations of angular and parity channels.
 
     :param max_angular: The maximum angular order for which CG coefficients should be
         computed and stored. This must be large enough to cover the maximum angular
         order reached in the CG iterations on a density input to the :py:meth:`compute`
         method.
     :param correlation_order: The desired correlation order of the output descriptor.
-        Must be >= 1.
+        Must be >= 1. The resulting final :py:class:`TensorMap` will have be of
+        body-order ``correlation_order + 1``.
     :param angular_cutoff: The maximum angular channel to compute at any given CG
         iteration, applied globally to all iterations until the target correlation order
         is reached.

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_correlate_density.py
@@ -90,9 +90,10 @@ class DensityCorrelations(TorchModule):
         correspond to intermediary spherical components created during the calculation,
         i.e. a ``k_{i}`` used to be ``o3_lambda``.
 
-        This defaults to false for TensorMaps output at each requested iteration, such
-        that the keys are moved to properties. If wanting to use the output of this
-        class for further CG tensor products, this should be set to True.
+        This defaults to ``False`` for :py:class:`TensorMap` output at each requested
+        iteration, such that the keys are moved to properties. If you want to use the
+        output of this class for further CG tensor products, this should be set to
+        ``True``.
     :param arrays_backend: Determines the array backend, either ``"numpy"`` or
         ``"torch"``.
     :param cg_backend: Determines the backend for the CG combination. It can be

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
@@ -1,0 +1,288 @@
+"""
+Module containing a convenience calculator that returns the output of a CG tensor
+product between :py:call:`LambdaSoap` and :py:class:`SphericalExpansionByPair`
+equivariant descriptors.
+"""
+
+from typing import List, Optional, Union
+
+import numpy as np
+
+from .. import _dispatch
+from .._backend import (
+    Labels,
+    SphericalExpansion,
+    SphericalExpansionByPair,
+    TensorBlock,
+    TensorMap,
+    TorchModule,
+    TorchScriptClass,
+    operations,
+    torch_jit_export,
+    torch_jit_is_scripting,
+)
+from . import _coefficients, _utils
+from ._correlate_density import DensityCorrelations
+from ._correlate_tensors import CorrelateTensorWithDensity
+
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+# ======================================================================
+# ===== Public API functions
+# ======================================================================
+
+
+class LambdaSoap(TorchModule):
+    """
+    Computes a Lambda-SOAP equivariant descriptor.
+    """
+
+    def __init__(
+        self,
+        spherical_expansion_hypers: dict,
+        atom_types: Optional[List[int]] = None,
+        angular_cutoff: Optional[int] = None,
+        selected_keys: Optional[Labels] = None,
+    ) -> None:
+
+        self._spherical_expansion_hypers = spherical_expansion_hypers
+        self._atom_types = atom_types
+        self._spherical_expansion_calc = SphericalExpansion(
+            **spherical_expansion_hypers
+        )
+
+        density_correlations_hypers = {
+            "max_angular": self._spherical_expansion_hypers["max_angular"] * 2,
+            "body_order": 3,
+            "angular_cutoff": angular_cutoff,
+            "selected_keys": selected_keys,
+            "match_keys": ["center_type"],
+            "skip_redundant": True,
+            "output_selection": None,
+            "keep_l_in_keys": False,
+            "arrays_backend": None,
+            "cg_backend": None,
+        }
+        self._density_correlations_hypers = density_correlations_hypers
+        self._density_correlations_calc = DensityCorrelations(
+            **density_correlations_hypers
+        )
+
+    def forward(self, frames) -> TensorMap:
+        """
+        Calls the :py:meth:`LambdaSoap.compute` function.
+
+        This is intended for :py:class:`torch.nn.Module` compatibility, and should be
+        ignored in pure Python mode.
+        """
+        return self.compute(frames)
+
+    def compute(self, frames) -> TensorMap:
+        """
+        Computes the Lambda-SOAP descriptor for the given ``frames``.
+
+        :param frames: The input frames, i.e. ase Atoms objects.
+        """
+        # Compute the nu = 1 density and move "neighbor_type" to properties
+        density = self._spherical_expansion_calc.compute(frames)
+        if self._atom_types is None:
+            keys_to_move = ["neighbor_type"]
+        else:
+            keys_to_move = Labels(
+                names=["neighbor_type"],
+                values=_dispatch.int_array_like(
+                    self._atom_types, like=density.keys.values
+                ).reshape(-1, 1),
+            )
+        density = density.keys_to_properties(keys_to_move)
+
+        # Compute the nu = 2 lambda-SOAP descriptor
+        lsoap = self._density_correlations_calc.compute(density)
+
+        return lsoap
+
+
+class LambdaSoapXSphExByPair(TorchModule):
+    """
+    Computes a Lambda-SOAP equivariant descriptor and takes the CG tensor product with a
+    SphericalExansionByPair descriptor.
+    """
+
+    def __init__(
+        self,
+        spherical_expansion_hypers: dict,
+        spherical_expansion_by_pair_hypers: dict,
+        atom_types: Optional[List[int]] = None,
+        angular_cutoff: Optional[int] = None,
+        selected_keys: Optional[Labels] = None,
+    ) -> None:
+        super().__init__()
+
+        self._spherical_expansion_hypers = spherical_expansion_hypers
+        self._spherical_expansion_by_pair_hypers = spherical_expansion_by_pair_hypers
+        self._atom_types = atom_types
+        self._angular_cutoff = angular_cutoff
+        self._selected_keys = selected_keys
+        self._spherical_expansion_calc = SphericalExpansion(
+            **spherical_expansion_hypers
+        )
+        self._spherical_expansion_by_pair_calc = SphericalExpansionByPair(
+            **spherical_expansion_by_pair_hypers
+        )
+
+        density_correlations_hypers = {
+            # We will re-use the CG coefficients computed by the DensityCorrelations
+            # constructor when initializing the CorrelateTensorWithDensity calculator.
+            # As such, we need to increase the max_angular to cover two iterations of CG
+            # tensor products.
+            "max_angular": self._spherical_expansion_hypers["max_angular"] * 3,
+            "body_order": 3,
+            "angular_cutoff": self._angular_cutoff,
+            "selected_keys": None,  # only apply key selection when doing rho_i x g_ij
+            # The "center_type" key dimension will be renamed to "first_atom_type"
+            # for matching with the dimension of the same name in the pair density
+            "match_keys": ["first_atom_type"],
+            "skip_redundant": True,
+            "output_selection": None,
+            "keep_l_in_keys": True,
+            "arrays_backend": None,
+            "cg_backend": None,
+        }
+        self._density_correlations_hypers = density_correlations_hypers
+        self._density_correlations_calc = DensityCorrelations(
+            **density_correlations_hypers
+        )
+
+    def forward(self, frames) -> TensorMap:
+        """
+        Calls the :py:meth:`LambdaSoapXSphExByPair.compute` function.
+
+        This is intended for :py:class:`torch.nn.Module` compatibility, and should be
+        ignored in pure Python mode.
+        """
+        return self.compute(frames)
+
+    def compute(self, frames) -> TensorMap:
+        """
+        Computes the Lambda-SOAP descriptor for the given ``frames`` and takes the CG
+        tensor product with a SphericalExpansionByPair descriptor.
+
+        :param frames: The input frames, i.e. ase Atoms objects.
+        """
+        return self._correlate_tensor_with_density(frames, compute_metadata=False)
+
+    @torch_jit_export
+    def compute_metadata(self, frames) -> TensorMap:
+        """
+        Returns the metadata-only :py:class:`TensorMap` that would be output by the
+        function :py:meth:`compute` for the same calculator under the same settings,
+        without performing the actual Clebsch-Gordan tensor products.
+
+        :param density: A density descriptor of body order 2 (correlation order 1), in
+            :py:class:`TensorMap` format. This may be, for example, a rascaline
+            :py:class:`SphericalExpansion` or :py:class:`LodeSphericalExpansion`.
+            Alternatively, this could be multi-center descriptor, such as a pair
+            density.
+        """
+        return self._correlate_tensor_with_density(
+            frames,
+            compute_metadata=True,
+        )
+
+    def _correlate_tensor_with_density(
+        self, frames, compute_metadata: bool
+    ) -> TensorMap:
+
+        # Compute the nu = 1 density and move "neighbor_type" to properties
+        density = self._spherical_expansion_calc.compute(frames)
+
+        # Rename "center_type" -> "first_atom_type" in the keys, and "atom" ->
+        # "first_atom" in the samples for consistency with the pair density to be
+        # computed later.
+        density = operations.rename_dimension(
+            density, "keys", "center_type", "first_atom_type"
+        )
+        density = operations.rename_dimension(density, "samples", "atom", "first_atom")
+
+        # Move "neighbor_type" to "properties
+        if self._atom_types is None:
+            keys_to_move = ["neighbor_type"]
+        else:
+            keys_to_move = Labels(
+                names=["neighbor_type"],
+                values=_dispatch.int_array_like(
+                    self._atom_types, like=density.keys.values
+                ).reshape(-1, 1),
+            )
+        density = density.keys_to_properties(keys_to_move)
+
+        # Compute the nu = 2 lambda-SOAP descriptor
+        lsoap = self._density_correlations_calc.compute(density)
+
+        # Change "body_order" to "order_nu"
+        lsoap = operations.insert_dimension(lsoap, "keys", 0, "order_nu", 2)
+        lsoap = operations.remove_dimension(lsoap, "keys", "body_order")
+
+        # Compute the nu = 2 SphericalExpansionByPair descriptor
+        pair_density = self._spherical_expansion_by_pair_calc.compute(frames)
+
+        # Copy the "second_atom_type" key dimension to a new properties dimension called
+        # "second_atom_type" so that it is correlated.
+        pair_density = operations.append_dimension(
+            pair_density,
+            "keys",
+            "neighbor_type",
+            values=pair_density.keys["second_atom_type"],
+        )
+
+        # Manipulate the pair density metadata ready for CG tensor product
+        pair_density = pair_density.keys_to_properties(
+            keys_to_move=Labels(
+                names=["neighbor_type"],
+                values=_dispatch.int_array_like(
+                    self._atom_types, pair_density.keys.values
+                ).reshape(-1, 1),
+            )
+        )
+        pair_density = operations.insert_dimension(
+            pair_density, axis="keys", index=0, name="order_nu", values=1
+        )
+        pair_density = operations.rename_dimension(
+            pair_density, "properties", "neighbor_type", "neighbor_3_type"
+        )
+        pair_density = operations.rename_dimension(
+            pair_density, "properties", "n", "n_3"
+        )
+
+        # Initialize the CorrelateTensorWithDensity calculator. Re-use the CG
+        # coefficients computed by the DensityCorrelations constructor in when this
+        # class was initialized.
+        tensor_correlator_hypers = {
+            "max_angular": self._density_correlations_hypers["max_angular"],
+            "angular_cutoff": self._angular_cutoff,
+            "selected_keys": self._selected_keys,
+            "match_keys": ["first_atom_type"],
+            "match_samples": ["system", "first_atom"],
+            "keep_l_in_keys": False,
+            "arrays_backend": None,
+            "cg_backend": None,
+        }
+        tensor_correlator_calc = CorrelateTensorWithDensity(
+            **tensor_correlator_hypers,
+            # Re-use CG coefficients computed by DensityCorrelations
+            cg_coefficients=self._density_correlations_calc._cg_coefficients,
+        )
+
+        # Compute the CG tensor product of the two descriptors
+        if compute_metadata:
+            tensor_correlation = tensor_correlator_calc.compute_metadata(lsoap, pair_density)
+        else:
+            tensor_correlation = tensor_correlator_calc.compute(lsoap, pair_density)
+
+        return tensor_correlation

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
@@ -1,6 +1,6 @@
 """
 Module containing a convenience calculator that returns the output of a CG tensor
-product between :py:call:`LambdaSoap` and :py:class:`SphericalExpansionByPair`
+product between :py:call:`EquivariantPowerSpectrum` and :py:class:`SphericalExpansionByPair`
 equivariant descriptors.
 """
 
@@ -37,7 +37,7 @@ except ImportError:
 # ======================================================================
 
 
-class LambdaSoap(TorchModule):
+class EquivariantPowerSpectrum(TorchModule):
     """
     Computes a Lambda-SOAP equivariant descriptor.
     """
@@ -75,7 +75,7 @@ class LambdaSoap(TorchModule):
 
     def forward(self, frames) -> TensorMap:
         """
-        Calls the :py:meth:`LambdaSoap.compute` function.
+        Calls the :py:meth:`EquivariantPowerSpectrum.compute` function.
 
         This is intended for :py:class:`torch.nn.Module` compatibility, and should be
         ignored in pure Python mode.
@@ -107,7 +107,7 @@ class LambdaSoap(TorchModule):
         return lsoap
 
 
-class LambdaSoapXSphExByPair(TorchModule):
+class EquivariantPowerSpectrumByPair(TorchModule):
     """
     Computes a Lambda-SOAP equivariant descriptor and takes the CG tensor product with a
     SphericalExansionByPair descriptor.
@@ -160,7 +160,7 @@ class LambdaSoapXSphExByPair(TorchModule):
 
     def forward(self, frames) -> TensorMap:
         """
-        Calls the :py:meth:`LambdaSoapXSphExByPair.compute` function.
+        Calls the :py:meth:`EquivariantPowerSpectrumByPair.compute` function.
 
         This is intended for :py:class:`torch.nn.Module` compatibility, and should be
         ignored in pure Python mode.
@@ -270,6 +270,9 @@ class LambdaSoapXSphExByPair(TorchModule):
             pair_density, "properties", "n", "n_2"
         )
 
+        # Symmetrise permutations. TODO: finish function
+        pair_density = _utils._symmetrise_permutations(pair_density)
+
         # Initialize the CorrelateTensorWithDensity calculator. Re-use the CG
         # coefficients computed by the DensityCorrelations constructor in when this
         # class was initialized.
@@ -302,3 +305,6 @@ class LambdaSoapXSphExByPair(TorchModule):
             tensor_correlation = tensor_correlator_calc.compute(density, pair_density)
 
         return tensor_correlation
+
+
+

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_lambda_soap.py
@@ -270,7 +270,7 @@ class EquivariantPowerSpectrumByPair(TorchModule):
             pair_density, "properties", "n", "n_2"
         )
 
-        # Symmetrise permutations. TODO: finish function
+        # Symmetrise permutations. TODO: to remove
         pair_density = _utils._symmetrise_permutations(pair_density)
 
         # Initialize the CorrelateTensorWithDensity calculator. Re-use the CG

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
@@ -102,8 +102,7 @@ def parse_selected_keys(
 
     if not len(selected_keys_) == n_iterations:
         raise ValueError(
-            "`selected_keys` must be a List[Labels] of length"
-            " `correlation_order` - 1"
+            "`selected_keys` must be a List[Labels] of length" " `body_order` - 2"
         )
 
     # Now iterate over each of the Labels (or None) in the list and check
@@ -144,62 +143,28 @@ def parse_selected_keys(
     return selected_keys_
 
 
-def parse_bool_iteration_filters(
-    n_iterations: int,
-    skip_redundant: Union[bool, List[bool]] = False,
-    output_selection: Optional[Union[bool, List[bool]]] = None,
-    keep_l_in_keys: Optional[Union[bool, List[bool]]] = None,
-) -> Tuple[List[bool], List[bool]]:
+def parse_bool_iteration_filter(
+    n_iterations: int, bool_filter: Union[bool, List[bool]], filter_name: str
+) -> List[bool]:
     """
-    Parses the ``skip_redundant`` and ``output_selection`` arguments passed to
-    public functions.
+    Parses the ``bool_filter`` argument passed to public functions.
     """
-    if isinstance(skip_redundant, bool):
-        skip_redundant_ = [skip_redundant] * n_iterations
+    if bool_filter is None:
+        bool_filter = [False] * (n_iterations - 1) + [True]
+    if isinstance(bool_filter, bool):
+        bool_filter_ = [bool_filter] * n_iterations
     else:
-        skip_redundant_ = skip_redundant
+        bool_filter_ = bool_filter
 
-    if not all([isinstance(val, bool) for val in skip_redundant_]):
-        raise TypeError("`skip_redundant` must be a `bool` or `list` of `bool`")
-    if not len(skip_redundant_) == n_iterations:
+    if not all([isinstance(val, bool) for val in bool_filter_]):
+        raise TypeError(f"`{filter_name}` must be a `bool` or `list` of `bool`")
+    if not len(bool_filter_) == n_iterations:
         raise ValueError(
-            "`skip_redundant` must be a bool or `list` of `bool` of length"
-            " `correlation_order` - 1"
-        )
-    if output_selection is None:
-        output_selection = [False] * (n_iterations - 1) + [True]
-    else:
-        if isinstance(output_selection, bool):
-            output_selection = [output_selection] * n_iterations
-        if not isinstance(output_selection, list):
-            raise TypeError("`output_selection` must be passed as `list` of `bool`")
-
-    if not len(output_selection) == n_iterations:
-        raise ValueError(
-            "`output_selection` must be a ``list`` of ``bool`` of length"
-            " corresponding to the number of CG iterations"
-        )
-    if not all([isinstance(v, bool) for v in output_selection]):
-        raise TypeError("`output_selection` must be passed as a `list` of `bool`")
-    if not all([isinstance(v, bool) for v in output_selection]):
-        raise TypeError("`output_selection` must be passed as a `list` of `bool`")
-
-    if isinstance(keep_l_in_keys, bool):
-        keep_l_in_keys_ = [
-            keep_l_in_keys if output else False for output in output_selection
-        ]
-    else:
-        keep_l_in_keys_ = keep_l_in_keys
-
-    if not all([isinstance(val, bool) for val in keep_l_in_keys_]):
-        raise TypeError("`keep_l_in_keys` must be a `bool` or `list` of `bool`")
-    if not len(keep_l_in_keys_) == n_iterations:
-        raise ValueError(
-            "`keep_l_in_keys` must be a bool or `list` of `bool` of length"
-            " `correlation_order` - 1"
+            f"`{filter_name}` must be a bool or `list` of `bool` of length"
+            " corresponding to the number of iterations, i.e. `body_order` - 2"
         )
 
-    return skip_redundant_, output_selection, keep_l_in_keys_
+    return bool_filter_
 
 
 class Combination:
@@ -222,7 +187,7 @@ def precompute_keys(
 ) -> Tuple[Labels, List[Combination]]:
     """
     Pre-compute the output keys after a single CG iteration combining ``keys_1`` and
-    ``key2_1``.
+    ``keys_2``.
 
     This function returns the computed keys, and a list of tuple of integers, indicating
     for each entries in the output keys which entry of the two set of input keys should

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
@@ -7,7 +7,7 @@ Private module containing helper functions for public module
 from typing import List, Optional, Tuple, Union
 
 from .. import _dispatch
-from .._backend import Array, Labels, TensorBlock, TensorMap, is_labels
+from .._backend import Array, Labels, TensorBlock, TensorMap, is_labels, operations
 from . import _coefficients
 
 
@@ -705,10 +705,10 @@ def _broadcast_first_block_samples(
     """
     Broadcasts the values tensor of ``block_1`` along the samples dimension to match
     those of ``block_2`` and returns the modified :py:class:`TensorBlock`.
-    
+
     Assumes that ``block_1`` has samples that are a subset of those of ``block_2``, and
-    are matching in the dimensions named in ``match_samples``. 
-    
+    are matching in the dimensions named in ``match_samples``.
+
     Returns ``block_1`` with the same samples metadata as ``block_2`` and broadcasted
     values along this axis.
     """
@@ -737,7 +737,9 @@ def _symmetrise_permutations(pairs: TensorMap) -> TensorMap:
     Symmetrise the permutations of the samples in the pairwise SphericalExpansion.
     """
     raise NotImplementedError("This function is not yet implemented.")
-    new_pairs = operations.insert_dimension(pairs, axis="samples", index=len(pairs.sample_names), name="sign", values=1)
+    new_pairs = operations.insert_dimension(
+        pairs, axis="samples", index=len(pairs.sample_names), name="sign", values=1
+    )
 
     new_blocks = []
 
@@ -759,7 +761,7 @@ def _symmetrise_permutations(pairs: TensorMap) -> TensorMap:
 
             if i == j and x == 0 and y == 0 and z == 0:  # on-site
                 continue
-            
+
             # Create the negative label and append the negative permutation
             negative_label = torch.tensor([A, j, i, x, y, z, -sign], dtype=torch.int32)
             new_samples.append(sample.values)
@@ -770,7 +772,6 @@ def _symmetrise_permutations(pairs: TensorMap) -> TensorMap:
             # new_samples.append(negative_label)
             # new_values.append(block.values[block.samples.])
 
-
         new_block = mts.TensorBlock(
             values=new_values,
             samples=new_samples,
@@ -778,7 +779,6 @@ def _symmetrise_permutations(pairs: TensorMap) -> TensorMap:
             properties=block.properties,
         )
         new_blocks.append(new_block)
-
 
     new_pairs = mts.TensorMap(pairs.keys, new_blocks)
 

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
@@ -732,6 +732,59 @@ def _broadcast_first_block_samples(
     )
 
 
+def _symmetrise_permutations(pairs: TensorMap) -> TensorMap:
+    """
+    Symmetrise the permutations of the samples in the pairwise SphericalExpansion.
+    """
+    raise NotImplementedError("This function is not yet implemented.")
+    new_pairs = operations.insert_dimension(pairs, axis="samples", index=len(pairs.sample_names), name="sign", values=1)
+
+    new_blocks = []
+
+    for key, block in pairs.items():
+        same_types = key["first_atom_type"] == key["second_atom_type"]
+
+        if not same_types:
+            new_blocks.append(block)
+            continue
+
+        new_values, new_samples = [], []
+        for i_sample, sample in enumerate(samples):
+
+            A, i, j, x, y, z, sign = sample
+
+            # Always include the positive permutation
+            new_samples.append(sample.values)
+            new_values.append(block.values[i_sample])
+
+            if i == j and x == 0 and y == 0 and z == 0:  # on-site
+                continue
+            
+            # Create the negative label and append the negative permutation
+            negative_label = torch.tensor([A, j, i, x, y, z, -sign], dtype=torch.int32)
+            new_samples.append(sample.values)
+            new_values.append(block.values[i_sample])
+
+            # TODO: finish this function
+
+            # new_samples.append(negative_label)
+            # new_values.append(block.values[block.samples.])
+
+
+        new_block = mts.TensorBlock(
+            values=new_values,
+            samples=new_samples,
+            components=block.components,
+            properties=block.properties,
+        )
+        new_blocks.append(new_block)
+
+
+    new_pairs = mts.TensorMap(pairs.keys, new_blocks)
+
+    return mts.sort(new_pairs)
+
+
 # ======================================================================= #
 # ======== Functions to perform the CG tensor products of blocks ======== #
 # ======================================================================= #

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
@@ -673,7 +673,7 @@ def cg_tensor_product_blocks_same_samples(
     combined_nu = int((len(block_1.properties.names) / 2) + 1)
 
     # TODO: this should be generalized not to hard-code the property dimension names
-    # here. 
+    # here.
     # Define the new property names for "n_<i>" and "neighbor_<i>_type"
     n_names = [f"n_{i}" for i in range(1, combined_nu + 1)]
     neighbor_names = [f"neighbor_{i}_type" for i in range(1, combined_nu + 1)]

--- a/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
+++ b/python/rascaline/rascaline/utils/clebsch_gordan/_utils.py
@@ -148,6 +148,7 @@ def parse_bool_iteration_filters(
     n_iterations: int,
     skip_redundant: Union[bool, List[bool]] = False,
     output_selection: Optional[Union[bool, List[bool]]] = None,
+    keep_l_in_keys: Optional[Union[bool, List[bool]]] = None,
 ) -> Tuple[List[bool], List[bool]]:
     """
     Parses the ``skip_redundant`` and ``output_selection`` arguments passed to
@@ -183,7 +184,22 @@ def parse_bool_iteration_filters(
     if not all([isinstance(v, bool) for v in output_selection]):
         raise TypeError("`output_selection` must be passed as a `list` of `bool`")
 
-    return skip_redundant_, output_selection
+    if isinstance(keep_l_in_keys, bool):
+        keep_l_in_keys_ = [
+            keep_l_in_keys if output else False for output in output_selection
+        ]
+    else:
+        keep_l_in_keys_ = keep_l_in_keys
+
+    if not all([isinstance(val, bool) for val in keep_l_in_keys_]):
+        raise TypeError("`keep_l_in_keys` must be a `bool` or `list` of `bool`")
+    if not len(keep_l_in_keys_) == n_iterations:
+        raise ValueError(
+            "`keep_l_in_keys` must be a bool or `list` of `bool` of length"
+            " `correlation_order` - 1"
+        )
+
+    return skip_redundant_, output_selection, keep_l_in_keys_
 
 
 class Combination:

--- a/python/rascaline/tests/utils/correlate_density.py
+++ b/python/rascaline/tests/utils/correlate_density.py
@@ -283,7 +283,6 @@ def test_lambda_soap_vs_powerspectrum():
     # Manipulate metadata to match that of PowerSpectrum:
     # 1) remove components axis
     # 2) change "l1" and "l2" properties dimensions to just "l" (as l1 == l2)
-    # 3) rename properties dimensions "neighbor_type_{x}" -> "neighbor_{x}_type"
     blocks = []
     for block in lsoap.blocks():
         n_samples, n_props = block.values.shape[0], block.values.shape[2]
@@ -623,21 +622,21 @@ def test_correlate_density_match_keys():
     lsoap_2 = calculator_2.compute(density_2)
 
     # Now do manual matching by slicing the properties dimension of lsoap_2,
-    # i.e. identifying where "neighbor_type_1" == "neighbor_type_2"
+    # i.e. identifying where "neighbor_1_type_1" == "neighbor_2_type"
     lsoap_2 = metatensor.rename_dimension(
-        lsoap_2, "properties", "neighbor_type_1", "neighbor_type"
+        lsoap_2, "properties", "neighbor_1_type", "neighbor_type"
     )
     lsoap_2 = metatensor.permute_dimensions(lsoap_2, "properties", [2, 4, 0, 1, 3, 5])
     new_blocks = []
     for block in lsoap_2:
         properties_filter = block.properties.column(
             "neighbor_type"
-        ) == block.properties.column("neighbor_type_2")
+        ) == block.properties.column("neighbor_2_type")
         new_properties = Labels(
             names=block.properties.names,
             values=block.properties.values[properties_filter],
         )
-        new_properties = new_properties.remove("neighbor_type_2")
+        new_properties = new_properties.remove("neighbor_2_type")
         new_blocks.append(
             TensorBlock(
                 values=block.values[:, :, properties_filter],

--- a/python/rascaline/tests/utils/correlate_density.py
+++ b/python/rascaline/tests/utils/correlate_density.py
@@ -290,8 +290,6 @@ def test_lambda_soap_vs_powerspectrum():
         new_props = block.properties
         new_props = new_props.remove(name="l_1")
         new_props = new_props.rename(old="l_2", new="l")
-        new_props = new_props.rename(old="neighbor_type_1", new="neighbor_1_type")
-        new_props = new_props.rename(old="neighbor_type_2", new="neighbor_2_type")
         blocks.append(
             TensorBlock(
                 values=block.values.reshape((n_samples, n_props)),

--- a/python/rascaline/tests/utils/correlate_density.py
+++ b/python/rascaline/tests/utils/correlate_density.py
@@ -203,6 +203,7 @@ def test_so3_equivariance():
         body_order=body_order_target,
         angular_cutoff=angular_cutoff,
         selected_keys=selected_keys,
+        match_keys=["center_type"],
     )
     nu_3 = calculator.compute(nu_1)
     nu_3_so3 = calculator.compute(nu_1_so3)
@@ -237,6 +238,7 @@ def test_o3_equivariance():
         body_order=body_order_target,
         angular_cutoff=angular_cutoff,
         selected_keys=selected_keys,
+        match_keys=["center_type"],
     )
     nu_3 = calculator.compute(nu_1)
     nu_3_o3 = calculator.compute(nu_1_o3)
@@ -267,6 +269,7 @@ def test_lambda_soap_vs_powerspectrum():
         max_angular=SPHEX_HYPERS["max_angular"],
         body_order=3,
         selected_keys=Labels(names=["o3_lambda"], values=np.array([0]).reshape(-1, 1)),
+        match_keys=["center_type"],
     )
     lsoap = calculator.compute(density)
     keys = lsoap.keys.remove(name="o3_lambda")
@@ -319,6 +322,7 @@ def test_correlate_density_norm(body_order):
         body_order=body_order,
         angular_cutoff=None,
         selected_keys=None,
+        match_keys=["center_type"],
         skip_redundant=False,
     )
     corr_calculator_skip_redundant = DensityCorrelations(
@@ -326,6 +330,7 @@ def test_correlate_density_norm(body_order):
         body_order=body_order,
         angular_cutoff=None,
         selected_keys=None,
+        match_keys=["center_type"],
         skip_redundant=True,
     )
     nux = calculator.compute(nu1)
@@ -473,11 +478,13 @@ def test_correlate_density_dense_sparse_agree():
         max_angular=SPHEX_HYPERS_SMALL["max_angular"] * (body_order - 1),
         body_order=body_order,
         cg_backend="python-sparse",
+        match_keys=["center_type"],
     )
     corr_calculator_dense = DensityCorrelations(
         max_angular=SPHEX_HYPERS_SMALL["max_angular"] * (body_order - 1),
         body_order=body_order,
         cg_backend="python-dense",
+        match_keys=["center_type"],
     )
     # NOTE: testing the private function here so we can control the use of
     # sparse v dense CG cache
@@ -510,6 +517,7 @@ def test_correlate_density_metadata_agree():
             body_order=4,
             angular_cutoff=3,
             selected_keys=None,
+            match_keys=["center_type"],
             skip_redundant=skip_redundant,
         )
         # Build higher body order tensor with CG computation
@@ -542,6 +550,7 @@ def test_correlate_density_angular_selection(
         body_order=body_order,
         angular_cutoff=None,
         selected_keys=selected_keys,
+        match_keys=["center_type"],
         skip_redundant=skip_redundant,
         arrays_backend=arrays_backend,
     )

--- a/python/rascaline/tests/utils/correlate_density.py
+++ b/python/rascaline/tests/utils/correlate_density.py
@@ -261,6 +261,7 @@ def test_lambda_soap_vs_powerspectrum():
     lsoap = calculator.compute(density)
     keys = lsoap.keys.remove(name="o3_lambda")
     keys = keys.remove("o3_sigma")
+    keys = keys.remove("order_nu")
 
     # Manipulate metadata to match that of PowerSpectrum:
     # 1) remove components axis


### PR DESCRIPTION
Implements:

1. a lambda-SOAP (i.e. `EquivariantPowerSpectrum`) calculator that wraps `DensityCorrelations`
2. a `CorrelateTensorWithDensity` calculator that performs a single CG tensor product between a tensor of arbitrary body order and a density (body-order 2) tensor, where the samples between the tensor and density are different.
3. a `EquivariantPowerSpectrumByPair` calculator, which generates a `SphericalExpansion` and `SphericalExpansionByPair`, manipulates the metadata appropriately, then uses `CorrelateTensorWithDensity` calculator to perform `rho_i x g_ij` to generate an Equivariant power spectrum by pair

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--317.org.readthedocs.build/en/317/

<!-- readthedocs-preview rascaline end -->