### PR TITLE
Rename `master` to `main` in code

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,14 +2,14 @@ name: Build Python wheels
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
     # Check all PR
 
 concurrency:
   group: wheels-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-wheels:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,13 +2,13 @@ name: Coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # Check all PR
 
 concurrency:
   group: coverage-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   coverage:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,14 @@ name: Documentation
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
     # Check all PR
 
 concurrency:
   group: docs-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-and-publish:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,13 +2,13 @@ name: Python tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # Check all PR
 
 concurrency:
   group: python-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   tests:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -2,13 +2,13 @@ name: Rust tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # Check all PR
 
 concurrency:
   group: rust-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   tests:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -2,13 +2,13 @@ name: TorchScript tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # Check all PR
 
 concurrency:
   group: torch-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   tests:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Getting involved
 
 Contribution via merge requests are always welcome. Source code is
 available from `Github`_. Before submitting a merge request, please
-open an issue to discuss your changes. Use the only `master` branch
+open an issue to discuss your changes. Use the only `main` branch
 for submitting your requests.
 
 .. _`Github` : https://github.com/Luthaf/rascaline
@@ -84,11 +84,11 @@ repository on github, and then clone it locally:
     git clone <insert/your/fork/url/here>
     cd rascaline
 
-    # setup the local repository so that the master branch tracks changes in
-    # the main repository
+    # setup the local repository so that the main branch tracks changes in
+    # the original repository
     git remote add upstream https://github.com/Luthaf/rascaline/
     git fetch upstream
-    git branch master --set-upstream-to=upstream/master
+    git branch main --set-upstream-to=upstream/main
 
 Once you get the code locally, you will want to run the tests to check
 everything is working as intended. See the next section on this subject.

--- a/README.rst
+++ b/README.rst
@@ -61,14 +61,14 @@ For details, tutorials, and examples, please have a look at our `documentation`_
 
 .. _`documentation`: https://luthaf.fr/rascaline/index.html
 
-.. |test| image:: https://img.shields.io/github/check-runs/Luthaf/rascaline/master?logo=github&label=tests
+.. |test| image:: https://img.shields.io/github/check-runs/Luthaf/rascaline/main?logo=github&label=tests
     :alt: Tests status
-    :target: https://github.com/Luthaf/rascaline/actions?query=branch%3Amaster
+    :target: https://github.com/Luthaf/rascaline/actions?query=branch%3Amain
 
 .. |docs| image:: https://img.shields.io/badge/documentation-latest-sucess
     :alt: Documentation
     :target: `documentation`_
 
-.. |cov| image:: https://codecov.io/gh/Luthaf/rascaline/branch/master/graph/badge.svg
+.. |cov| image:: https://codecov.io/gh/Luthaf/rascaline/branch/main/graph/badge.svg
     :alt: Coverage Status
     :target: https://codecov.io/gh/Luthaf/rascaline


### PR DESCRIPTION
This should contain all code changes necessary to rename `master` to `main`

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--335.org.readthedocs.build/en/335/

<!-- readthedocs-preview rascaline end -->