### PR TITLE
Fix inaccuracy in `rotation_adapted.rst`

### DIFF
--- a/docs/src/explanations/rotation_adapted.rst
+++ b/docs/src/explanations/rotation_adapted.rst
@@ -111,4 +111,4 @@ density, and combining them with a CG iteration to a coupled basis, as in
     \frac{\delta_{\sigma, (-1)^{l_1 + l_2 + \lambda}}}{\sqrt{2 \lambda + 1}}
     \sum_{m} C_{m (\mu-m) \mu}^{l_1 l_2 \lambda} c_{n_1 l_1 m}^{i} c_{n_2 l_2 (\mu - m)}^{i}
 
-where we have assumed real spherical harmonics coefficients.
+where we have assumed complex spherical harmonics coefficients.


### PR DESCRIPTION
If it were real, we would need m1 and m2 indices

<!-- readthedocs-preview rascaline start -->
----
📚 Documentation preview 📚: https://rascaline--340.org.readthedocs.build/en/340/

<!-- readthedocs-preview rascaline end -->