### PR TITLE
Use metatensor public API instead of private methods

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -140,7 +140,7 @@ breathe_domain_by_extension = {
 }
 
 intersphinx_mapping = {
-    "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
+    "ase": ("https://docs.ase-lib.org/", None),
     "chemfiles": ("https://chemfiles.org/chemfiles.py/latest/", None),
     "metatensor": ("https://docs.metatensor.org/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),

--- a/python/featomic/featomic/calculator_base.py
+++ b/python/featomic/featomic/calculator_base.py
@@ -78,10 +78,10 @@ def _options_to_c(
         # nothing to do, all pointers are already NULL
         pass
     elif isinstance(selected_samples, Labels):
-        c_options.selected_samples.subset = selected_samples._as_mts_labels_t()
+        c_options.selected_samples.subset = selected_samples.as_mts_labels_t()
         c_options.__keepalive["selected_samples"] = selected_samples
     elif isinstance(selected_samples, TensorMap):
-        c_options.selected_samples.predefined = selected_samples._ptr
+        c_options.selected_samples.predefined = selected_samples.as_mts_tensormap_t()
     else:
         raise ValueError(
             "expected selected samples to be either an `metatensor.Labels` "
@@ -93,10 +93,10 @@ def _options_to_c(
         # nothing to do, all pointers are already NULL
         pass
     elif isinstance(selected_properties, Labels):
-        c_options.selected_properties.subset = selected_properties._as_mts_labels_t()
+        c_options.selected_properties.subset = selected_properties.as_mts_labels_t()
         c_options.__keepalive["selected_properties"] = selected_properties
     elif isinstance(selected_properties, TensorMap):
-        c_options.selected_properties.predefined = selected_properties._ptr
+        c_options.selected_properties.predefined = selected_properties.as_mts_tensormap_t()
     else:
         raise ValueError(
             "expected selected properties to be either an `metatensor.Labels` "
@@ -108,7 +108,7 @@ def _options_to_c(
         # nothing to do, all pointers are already NULL
         pass
     elif isinstance(selected_keys, Labels):
-        c_options.selected_keys = selected_keys._as_mts_labels_t()
+        c_options.selected_keys = selected_keys.as_mts_labels_t()
         c_options.__keepalive["selected_keys"] = selected_keys
     return c_options
 
@@ -308,4 +308,4 @@ class CalculatorBase:
             self, tensor_map_ptr, c_systems, c_systems._length_, c_options
         )
 
-        return TensorMap._from_ptr(tensor_map_ptr)
+        return TensorMap.unsafe_from_ptr(tensor_map_ptr)

--- a/python/featomic/featomic/calculator_base.py
+++ b/python/featomic/featomic/calculator_base.py
@@ -96,7 +96,9 @@ def _options_to_c(
         c_options.selected_properties.subset = selected_properties.as_mts_labels_t()
         c_options.__keepalive["selected_properties"] = selected_properties
     elif isinstance(selected_properties, TensorMap):
-        c_options.selected_properties.predefined = selected_properties.as_mts_tensormap_t()
+        c_options.selected_properties.predefined = (
+            selected_properties.as_mts_tensormap_t()
+        )
     else:
         raise ValueError(
             "expected selected properties to be either an `metatensor.Labels` "


### PR DESCRIPTION
## Description

featomic's Python package calls several metatensor methods that were made public in metatensor v0.2 (the leading underscore was dropped). metatensor only kept the private names around as backward-compat shims [for featomic](https://github.com/metatensor/metatensor/pull/1146), with the note *"used by featomic, kept here until we update featomic to use the public API."*

This PR is that update, migrating `calculator_base.py` to the public API:

| Before (private) | After (public) |
|---|---|
| `Labels._as_mts_labels_t()` | `Labels.as_mts_labels_t()` |
| `TensorMap._ptr` | `TensorMap.as_mts_tensormap_t()` |
| `TensorMap._from_ptr()` | `TensorMap.unsafe_from_ptr()` |

Semantics are unchanged: `as_mts_tensormap_t()` returns a borrowed pointer (metatensor keeps ownership), matching the old `._ptr` and the borrowed `predefined` field, while `unsafe_from_ptr()` takes ownership of the freshly-allocated result.

Once this lands, metatensor can drop the shims from metatensor#1146.

Fixes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/featomic/actions/artifacts/7862810311.zip)

<!-- download-section Documentation docs end -->